### PR TITLE
Mcp tool improvement

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -119,7 +119,10 @@ full whitelist details.
   "timestamp": "2026-01-01T00:00:00",
   "execution_time": 1.5,
   "command_count": 3,
-  "buffer_size": 2048,
+  "buffer_size": 131072,
+  "truncated": false,
+  "bytes_discarded": 0,
+  "total_bytes": 13,
   "error": null
 }
 ```
@@ -130,7 +133,16 @@ full whitelist details.
 | `session_id` | The session used (auto-created if none was passed) |
 | `execution_time` | Seconds spent on this command |
 | `command_count` | Commands executed in this session so far |
-| `buffer_size` | Current output-buffer occupancy in bytes |
+| `buffer_size` | The session buffer's capacity in characters |
+| `truncated` | `true` when output exceeded the buffer and its head was discarded |
+| `bytes_discarded` | Characters dropped from the **start** of the output |
+| `total_bytes` | Raw characters the command produced, before ANSI cleaning |
+
+> **Truncation warning.** Output larger than the session buffer loses its **beginning**, not its
+> end. When `truncated` is `true` the result is a **partial answer**: the retained text may start
+> mid-line, and any error or warning printed before the cut is not in `output` and is not
+> reflected in `error`. A truncated result also carries a `[TRUNCATED: ...]` banner at the head of
+> `output`. Narrow the command and re-run rather than analysing what came back.
 
 > **Session accumulation warning.** Omitting `session_id` creates a session and **leaves it
 > running**. Capture the returned `session_id` and reuse it, or you will accumulate sessions
@@ -463,9 +475,16 @@ When no images are found: `run_path`, `total_images`, and `images_by_stage` are 
 
 ### `read_report_image`
 
-Read a single `.webp` image and return its base64-encoded data with metadata. Images larger
-than 15 KB (base64) are automatically downscaled using sharp (lanczos3, WebP quality 85) before
-encoding. The 50 MB on-disk limit is enforced before any resizing.
+Read a single report image and return it as a **real MCP image content block** a vision model can
+see, plus a text block carrying the metadata. The base64 payload is *not* repeated in the text
+block.
+
+Images are downscaled only as far as their byte budget actually requires: the longest edge is
+capped at `OPENROAD_IMAGE_MAX_DIMENSION` (default 1568 px, the resolution vision models downsample
+to anyway), then a size/quality ladder steps down only while the encoding still exceeds
+`OPENROAD_IMAGE_MAX_BASE64_KB` (default 1024 KB of base64), never below
+`OPENROAD_IMAGE_MIN_DIMENSION` (default 512 px). Most report images now pass through untouched.
+The 50 MB on-disk limit is enforced before any resizing.
 
 | Parameter | Type | Required | Default |
 |-----------|------|----------|---------|
@@ -473,6 +492,10 @@ encoding. The 50 MB on-disk limit is enforced before any resizing.
 | `design` | string | **yes** | — |
 | `run_slug` | string | **yes** | — |
 | `image_name` | string | **yes** | — |
+| `max_size_kb` | integer | no | `OPENROAD_IMAGE_MAX_BASE64_KB` |
+
+`max_size_kb` overrides the base64 budget for a single call — lower it for a quick thumbnail,
+raise it when a heatmap needs more detail.
 
 `image_name` must end in `.webp` and may not contain path separators or traversal sequences.
 
@@ -482,7 +505,15 @@ encoding. The 50 MB on-disk limit is enforced before any resizing.
 - `idempotentHint: true`
 - `openWorldHint: false`
 
-**Response shape** (`read_image.json`):
+**Response shape.** The tool returns two content blocks:
+
+```
+[ { "type": "image", "data": "<base64>", "mimeType": "image/webp" },
+  { "type": "text",  "text": "<the JSON below, without image_data>" } ]
+```
+
+The underlying JSON payload (`read_image.json`, as returned by the library API which still
+includes `image_data`):
 
 ```json
 {
@@ -507,8 +538,10 @@ encoding. The 50 MB on-disk limit is enforced before any resizing.
 }
 ```
 
-`compression_ratio` is `original_size_bytes / size_bytes`. `compression_applied` is `true`
-when the original exceeded 15 KB (base64).
+`compression_ratio` is `original_size_bytes / size_bytes`. `compression_applied` is `true` only
+when the image actually had to be re-encoded; `format` is sniffed from the bytes rather than
+guessed from the filename, so the doubled `.webp.png` form some ORFS builds emit is reported
+correctly.
 
 **Error response** (`read_image_error.json`):
 
@@ -534,6 +567,9 @@ when the original exceeded 15 KB (base64).
 | Command history per session | 1000 entries | (constant) |
 | Default command timeout | 30 s | `OPENROAD_COMMAND_TIMEOUT` |
 | Input queue depth | 128 commands | `OPENROAD_SESSION_QUEUE_SIZE` |
+| Report-image payload | 1024 KB base64 | `OPENROAD_IMAGE_MAX_BASE64_KB` |
+| Report-image longest edge | 1568 px | `OPENROAD_IMAGE_MAX_DIMENSION` |
+| Report-image resize floor | 512 px | `OPENROAD_IMAGE_MIN_DIMENSION` |
 
 ### Idle Session Accumulation
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -179,6 +179,31 @@ use `interactive_openroad_query` when you want to keep state changes visible and
 The response shape is identical to `interactive_openroad_query`. Long-running flow commands
 routinely exceed 30 s — pass a larger `timeout_ms` for placement, CTS, and routing.
 
+#### Rendering a layout or timing-path image from a session
+
+A session is headless, but Qt renders offscreen, so `save_image` works — the GUI-only commands
+(`gui::show_worst_path`, `gui::set_display_controls`) just need a GUI event loop to exist first.
+`gui::show <script> false` provides one: it boots the GUI, runs the script, and returns. This is
+how ORFS writes its own report images (`flow/scripts/final_report.tcl`).
+
+```tcl
+gui::show {gui::set_display_controls "Timing Path/*" visible true
+           gui::show_worst_path
+           save_image -width 1920 /tmp/worst_path.png} false
+```
+
+`-width` is independent of die size; ORFS instead computes `-resolution` from the block height,
+which is why its images come out ~1000 px regardless of design.
+
+Set `QT_QPA_PLATFORM=offscreen` in the session's `env` when no display is present (ORFS does this
+automatically in `variables.mk`). A bare `gui::show`, or one left interactive, is **rejected** —
+it blocks the Tcl event loop waiting on a human, leaving the session alive but permanently
+unresponsive. The error message carries the working form.
+
+Before rendering anything, check whether the run already has the image: ORFS emits
+`final_worst_path.webp`, `final_congestion.webp` and others into `reports/`, and
+[`read_report_image`](#read_report_image) returns them directly with no session at all.
+
 ---
 
 ### `create_interactive_session`

--- a/docs/API.md
+++ b/docs/API.md
@@ -27,6 +27,7 @@ make golden
   - [inspect_interactive_session](#inspect_interactive_session)
   - [get_session_history](#get_session_history)
   - [get_session_metrics](#get_session_metrics)
+  - [grep_session_output](#grep_session_output)
 - [Report Image Tools](#report-image-tools)
   - [list_report_images](#list_report_images)
   - [read_report_image](#read_report_image)
@@ -425,6 +426,68 @@ No parameters.
 
 ---
 
+### `grep_session_output`
+
+Search the output of commands already run in a session, without re-running them or re-sending a
+large result.
+
+| Parameter | Type | Required | Default |
+|-----------|------|----------|---------|
+| `session_id` | string | **yes** | — |
+| `pattern` | string | **yes** | — |
+| `max_matches` | integer | no | `200` |
+| `context_lines` | integer | no | `0` |
+| `ignore_case` | boolean | no | `true` |
+| `command_number` | integer | no | — (all retained commands) |
+
+```json
+{
+  "session_id": "a1b2c3d4",
+  "pattern": "wns",
+  "matches": [
+    { "command_number": 1, "command": "report_checks", "line_number": 42, "line": "wns max -0.485" }
+  ],
+  "total_matches": 1,
+  "truncated": false,
+  "pattern_kind": "regex",
+  "searched_commands": 1,
+  "searched_lines": 900,
+  "retained_chars": 131166,
+  "evicted_commands": 0,
+  "message": null,
+  "error": null
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `total_matches` | Matches found, which exceeds `matches.length` when capped by `max_matches` |
+| `truncated` | `true` when matches were dropped — the list is not the whole answer |
+| `pattern_kind` | How the pattern was applied; see below |
+| `searched_commands` / `searched_lines` | How much was actually searched |
+| `retained_chars` | Characters of output currently held for this session |
+| `evicted_commands` | Commands whose output has aged out of the retention budget |
+
+**Pattern handling.** `pattern` is a regular expression. `pattern_kind` reports what actually
+happened:
+
+- `regex` — compiled and applied as a regex.
+- `substring` — the pattern did not compile, so it was applied literally. Pasting a raw name is not
+  treated as a user error.
+- `substring-fallback` — the pattern compiled *and matched nothing*, and it contains regex
+  metacharacters, so it was retried literally and that found matches. A pasted instance name like
+  `dpath.a_reg[0]` is valid regex meaning "…`a_reg` followed by `0`", which silently matches
+  nothing — worse than a syntax error, because you would be told there are no matches when it is
+  the pattern that is wrong.
+
+> **Only recent output is searchable.** `runCommand` drains the session's circular buffer, so the
+> live buffer holds nothing once a command has returned. Output is therefore retained separately,
+> bounded by `OPENROAD_OUTPUT_HISTORY_CHARS` (default 256 KB) and
+> `OPENROAD_OUTPUT_HISTORY_COMMANDS` (default 50), oldest evicted first. `evicted_commands` tells
+> you when something has aged out. A single result larger than the whole budget keeps its tail.
+
+---
+
 ## Report Image Tools
 
 ### `list_report_images`
@@ -799,6 +862,8 @@ server shutdown.
 | Report-image payload | 1024 KB base64 | `OPENROAD_IMAGE_MAX_BASE64_KB` |
 | Report-image longest edge | 1568 px | `OPENROAD_IMAGE_MAX_DIMENSION` |
 | Report-image resize floor | 512 px | `OPENROAD_IMAGE_MIN_DIMENSION` |
+| Searchable output per session | 256 KB | `OPENROAD_OUTPUT_HISTORY_CHARS` |
+| Searchable commands per session | 50 | `OPENROAD_OUTPUT_HISTORY_COMMANDS` |
 | Concurrent flow runs | 2 | `OPENROAD_MAX_FLOW_JOBS` |
 | Flow run timeout | 6 h | `OPENROAD_FLOW_RUN_TIMEOUT` |
 | Flow run log directory | `<tmpdir>/openroad-mcp-runs` | `OPENROAD_RUN_LOG_DIR` |

--- a/docs/API.md
+++ b/docs/API.md
@@ -32,6 +32,10 @@ make golden
   - [read_report_image](#read_report_image)
 - [ORFS Metrics Tools](#orfs-metrics-tools)
   - [read_orfs_metrics](#read_orfs_metrics)
+- [Flow Run Tools](#flow-run-tools)
+  - [run_orfs_stage](#run_orfs_stage)
+  - [get_orfs_job](#get_orfs_job)
+  - [cancel_orfs_job](#cancel_orfs_job)
 - [Session Lifecycle Notes](#session-lifecycle-notes)
 
 ---
@@ -672,6 +676,115 @@ present).
 
 ---
 
+## Flow Run Tools
+
+Run an ORFS stage through the server instead of shelling out to `make`. Output streams to a file —
+never through the session's 128 KB circular buffer, which would keep only the tail of a route log.
+
+> **What "inspectable" means here.** A `make`-spawned OpenROAD is a separate process this server
+> does not own, so **its Tcl interpreter cannot be queried mid-run**. `get_orfs_job` gives
+> *structured job progress* — stage, iteration, live violation count, CPU and memory — which is what
+> a caller would otherwise hand-roll from `tail`, `grep`, `ps` and `stat`. It is not live access to
+> the running interpreter.
+
+### `run_orfs_stage`
+
+| Parameter | Type | Required | Default |
+|-----------|------|----------|---------|
+| `design` | string | **yes** | — |
+| `stage` | string | **yes** | — |
+| `overrides` | object | no | `{}` |
+| `platform` | string | no | inferred from `design` |
+| `variant` | string | no | `base` |
+| `wait_seconds` | integer | no | — (return immediately) |
+| `jobs` | integer | no | — (make default) |
+| `timeout_seconds` | integer | no | `OPENROAD_FLOW_RUN_TIMEOUT` (6 h) |
+| `dry_run` | boolean | no | `false` |
+
+Returns a `job_id` immediately so a multi-hour route does not block the call. Pass `wait_seconds`
+to get the finished result inline when the stage is short. `dry_run: true` runs `make -n`, showing
+which stages the target would chain without running any of them.
+
+`overrides` become **make command-line assignments**, which take precedence over both the
+environment and the Makefile:
+
+```json
+{ "design": "gcd", "stage": "cts", "overrides": { "CTS_CLUSTER_SIZE": "20" } }
+```
+
+Override names are returned verbatim, not converted to snake_case.
+
+**Allowed `stage` values:** `synth`, `floorplan`, `place`, `cts`, `grt`, `route`, `finish`, `all`,
+`metadata`, and `clean_synth` / `clean_floorplan` / `clean_place` / `clean_cts` / `clean_route` /
+`clean_finish` / `clean_metadata` / `clean_all`. Anything else is rejected — see
+[SECURITY.md](SECURITY.md) for why the allowlist exists and which override names are refused.
+
+**Annotations:** `readOnlyHint: false`, `destructiveHint: true` — it writes into the flow tree, and
+the `clean_*` targets delete results.
+
+### `get_orfs_job`
+
+| Parameter | Type | Required | Default |
+|-----------|------|----------|---------|
+| `job_id` | string | no | — (list every run) |
+| `recent_lines` | integer | no | `50` |
+
+```json
+{
+  "job_id": "a3f2c1d0",
+  "status": "running",
+  "design": "ibex",
+  "stage": "route",
+  "command": "make route DESIGN_CONFIG=./designs/sky130hd/ibex/config.mk FLOW_VARIANT=base",
+  "elapsed_seconds": 1840,
+  "progress": {
+    "current_stage": "5_2_route",
+    "iteration": 1,
+    "percent": 80,
+    "violations": 19604,
+    "iteration_violations": 20,
+    "cpu_seconds": 1802,
+    "memory_mb": 4210.5,
+    "peak_memory_mb": 4300.0
+  },
+  "recent_lines": ["    Completing 80% with 19604 violations."],
+  "log_path": "/tmp/openroad-mcp-runs/a3f2c1d0.log",
+  "log_bytes": 48210934,
+  "log_truncated": true,
+  "stages": [],
+  "gates": [],
+  "error": null
+}
+```
+
+`status` is `running`, `succeeded`, `failed`, `cancelled` or `timed_out`, with `exit_code` always
+present once finished. **On success the result also carries `stages`, `gates` and `gate_summary`**
+in the same shape [read_orfs_metrics](#read_orfs_metrics) returns — including repeated metrics as
+arrays.
+
+`current_stage` comes from the newest `*.tmp.log` in the run's logs directory: ORFS writes each
+stage to `<stem>.tmp.log` and renames it to `<stem>.log` on success, so this tracks the flow without
+depending on stage numbering. `cpu_seconds` and `memory_mb` come from OpenROAD's own `DRT-0267`
+line, not from sampling the `make` pid — the process consuming the machine is a grandchild.
+
+`log_truncated` reports that the log holds more than the lines returned; `log_bytes` is the true
+total.
+
+### `cancel_orfs_job`
+
+| Parameter | Type | Required |
+|-----------|------|----------|
+| `job_id` | string | **yes** |
+
+Signals the run's **entire process group**, then escalates to `SIGKILL` after a grace period.
+Killing only `make` would strand the `openroad` it spawned. Running jobs are also torn down on
+server shutdown.
+
+**Error codes** across these tools: `ValidationError` (bad design/variant/stage/override),
+`FlowJobLimit` (concurrency cap reached), `FlowJobNotFound`, `FlowPathNotFound`.
+
+---
+
 ## Session Lifecycle Notes
 
 ### Limits
@@ -686,6 +799,9 @@ present).
 | Report-image payload | 1024 KB base64 | `OPENROAD_IMAGE_MAX_BASE64_KB` |
 | Report-image longest edge | 1568 px | `OPENROAD_IMAGE_MAX_DIMENSION` |
 | Report-image resize floor | 512 px | `OPENROAD_IMAGE_MIN_DIMENSION` |
+| Concurrent flow runs | 2 | `OPENROAD_MAX_FLOW_JOBS` |
+| Flow run timeout | 6 h | `OPENROAD_FLOW_RUN_TIMEOUT` |
+| Flow run log directory | `<tmpdir>/openroad-mcp-runs` | `OPENROAD_RUN_LOG_DIR` |
 
 ### Idle Session Accumulation
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -30,6 +30,8 @@ make golden
 - [Report Image Tools](#report-image-tools)
   - [list_report_images](#list_report_images)
   - [read_report_image](#read_report_image)
+- [ORFS Metrics Tools](#orfs-metrics-tools)
+  - [read_orfs_metrics](#read_orfs_metrics)
 - [Session Lifecycle Notes](#session-lifecycle-notes)
 
 ---
@@ -553,6 +555,120 @@ correctly.
   "error": "ImageNotFound"
 }
 ```
+
+---
+
+## ORFS Metrics Tools
+
+### `read_orfs_metrics`
+
+Read a design's per-stage metrics, evaluate its `rules-base.json` gate thresholds against them, and
+surface the tagged errors and warnings from each stage log — in one call. This replaces the
+`find` + `cat` + `jq` + `grep` sequence over the flow tree that accounted for roughly 39% of all
+shell usage in the capability study.
+
+| Parameter | Type | Required | Default |
+|-----------|------|----------|---------|
+| `design` | string | **yes** | — |
+| `stage` | string | no | `all` |
+| `platform` | string | no | inferred from `design` |
+| `variant` | string | no | `base` |
+
+`platform` is inferred when the design name is unique across platforms; if it is not, the error
+names the candidates. `design` and `variant` are validated as single path segments.
+
+**Stage resolution.** `stage` is matched, in order, against:
+
+1. an exact file stem — `4_1_cts`
+2. an **ORFS metric namespace** — `placeopt`, `detailedplace`, `globalplace`, `globalroute`,
+   `detailedroute`, `finish`. These matter because `rules-base.json` keys metrics by namespace
+   (`globalroute__timing__setup__ws`) while the file on disk is `5_1_grt.json`.
+3. an everyday **stage group** — `synth`, `floorplan`, `place`, `cts`, `route`, `finish`, which
+   expand to every step in that group (`place` → all five `3_*` files)
+4. a plain substring of the stem
+5. `all` (the default) — every stage
+
+Stages are discovered from the logs directory rather than a hardcoded table, so a renumbered ORFS
+release still resolves. An unmatched stage returns `StageNotFound` listing the stems present.
+
+> **Repeated metrics are arrays.** ORFS appends a block of metrics per sub-run, so a stage file
+> legitimately contains the same key more than once — the real `4_1_cts.json` has 63 key
+> occurrences across 55 distinct keys, recording `cts__utilization__before__dpl` as both `76.7787`
+> and `82.1146`. A plain `JSON.parse` keeps only the last and reports nothing. This tool returns
+> **every** value, in file order, and names those keys in `repeated_metrics` so you can tell an
+> array from a scalar without inspecting each value. Gates on such a metric are judged on the
+> **last** value (what ORFS's own checkers see) and marked `"ambiguous": true`.
+
+**Response shape:**
+
+```json
+{
+  "platform": "nangate45",
+  "design": "gcd",
+  "variant": "base",
+  "stage": "cts",
+  "logs_path": "logs/nangate45/gcd/base",
+  "available_stages": ["1_synth", "2_1_floorplan", "...", "6_report"],
+  "stages": [
+    {
+      "stage": "4_1_cts",
+      "metrics_path": "logs/nangate45/gcd/base/4_1_cts.json",
+      "metrics": {
+        "cts__utilization__before__dpl": [76.7787, 82.1146],
+        "cts__timing__setup__ws": -0.113089,
+        "cts__design__violations": 0
+      },
+      "repeated_metrics": ["cts__utilization__before__dpl"],
+      "log": {
+        "path": "logs/nangate45/gcd/base/4_1_cts.log",
+        "errors": ["[ERROR ORD-2018] Pin is not ITerm or BTerm or modITerm."],
+        "warnings": [],
+        "error_count": 1,
+        "warning_count": 0,
+        "truncated": false
+      },
+      "error": null
+    }
+  ],
+  "gates": [
+    {
+      "metric": "cts__timing__setup__ws",
+      "stage": "4_1_cts",
+      "value": -0.113089,
+      "threshold": -0.0529,
+      "compare": ">=",
+      "level": "error",
+      "status": "fail"
+    }
+  ],
+  "unmatched_gates": [
+    { "metric": "finish__timing__setup__ws", "threshold": -0.0559, "compare": ">=", "level": "error" }
+  ],
+  "gate_summary": {
+    "total": 1, "pass": 0, "fail": 1, "unknown": 0,
+    "failing_errors": 1, "failing_warnings": 0, "unmatched": 1
+  },
+  "rules_path": "designs/nangate45/gcd/rules-base.json",
+  "message": null,
+  "error": null
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `stages[].metrics` | The stage's metrics; a value is an **array** iff its key is in `repeated_metrics` |
+| `stages[].metrics_path` | `null` when the stage produced a log but no metrics file (a crashed stage) |
+| `stages[].error` | `MalformedMetrics: ...` when the JSON is half-written; the stage is still returned |
+| `stages[].log.truncated` | `true` when more diagnostics existed than the 50-per-category listed |
+| `gates[].status` | `pass`, `fail`, or `unknown` when the operator cannot apply to the value |
+| `gates[].level` | From the rule; a rule with no `level` defaults to `error`, as ORFS does |
+| `unmatched_gates` | Rules whose metric was not in the stages read — use `stage: "all"` to cover them |
+
+All paths are returned **relative to the ORFS flow root**, never as absolute host paths.
+
+**Error codes:** `ValidationError` (bad design/variant/platform, or path traversal), `RunNotFound`
+(no such variant; the message lists those present), `StageNotFound` (the message lists the stems
+present).
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -555,6 +555,14 @@ to anyway), then a size/quality ladder steps down only while the encoding still 
 `OPENROAD_IMAGE_MIN_DIMENSION` (default 512 px). Most report images now pass through untouched.
 The 50 MB on-disk limit is enforced before any resizing.
 
+**Quality is shed before resolution.** Every quality rung (85, 70, 55) is tried at the current
+size before the image is made smaller, and the first encoding that fits the budget is returned.
+A congestion or routing map carries its signal in fine wire and via detail, which downsampling
+destroys outright, while WebP quality loss degrades it gracefully — so a full-resolution q70
+image is returned in preference to a downscaled q85 one. `width`/`height` in the response are
+the dimensions actually returned; compare them against `original_width`/`original_height` to see
+whether resizing was reached at all.
+
 | Parameter | Type | Required | Default |
 |-----------|------|----------|---------|
 | `platform` | string | **yes** | — |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -216,6 +216,23 @@ under the base directory. A symlink that points outside the base is caught here.
   12 encode attempts. A caller raising `max_size_kb` raises the payload this server will emit;
   the 50 MB on-disk cap above still bounds what is read.
 
+### `read_orfs_metrics` path handling
+
+`read_orfs_metrics` reads only two locations under the ORFS flow root — the stage metrics and logs
+in `logs/<platform>/<design>/<variant>/`, and `designs/<platform>/<design>/rules-base.json`. It
+writes nothing and executes nothing.
+
+- `design` and `variant` are validated as single path segments (`validatePathSegment`), so
+  separators, `..`, null bytes and glob characters are rejected.
+- The resolved logs directory is checked with `validateSafePathContainment` against
+  `<flow>/logs`, which resolves symlinks in existing parents, so a symlinked run directory cannot
+  escape the flow tree.
+- `platform` is not free-form: it is either inferred from the design or checked against the
+  platforms ORFS actually has.
+- Every path in the response is relative to the flow root, so absolute host paths are not disclosed.
+- Stage logs are returned filtered to ORFS's own `[ERROR ...]` / `[WARNING ...]` lines, capped at
+  50 per category per stage, rather than as raw log contents.
+
 **Known image filename mappings:**
 
 Images are classified by filename stem: the `stage` is the prefix before the first `_`, and the

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -163,6 +163,9 @@ All variables are read at startup by [`typescript/src/config/settings.ts`](../ty
 | `OPENROAD_IMAGE_MAX_BASE64_KB` | integer (KB) | `1024` | Report-image payload budget; override per-call with `max_size_kb` |
 | `OPENROAD_IMAGE_MAX_DIMENSION` | integer (pixels) | `1568` | Longest edge an image is capped to before encoding |
 | `OPENROAD_IMAGE_MIN_DIMENSION` | integer (pixels) | `512` | Floor below which the resize ladder will not shrink |
+| `OPENROAD_MAX_FLOW_JOBS` | integer | `2` | Concurrent `run_orfs_stage` runs allowed |
+| `OPENROAD_FLOW_RUN_TIMEOUT` | float (seconds) | `21600` (6 h) | Default wall-clock budget for a flow run |
+| `OPENROAD_RUN_LOG_DIR` | path | `<tmpdir>/openroad-mcp-runs` | Where flow-run logs are streamed |
 | `OPENROAD_ALLOWED_COMMANDS` | string (comma-separated) | `openroad` | PTY spawn executable allowlist |
 | `OPENROAD_ENABLE_COMMAND_VALIDATION` | bool | `true` | Enables/disables `PtyHandler.validateCommand` |
 | `OPENROAD_WHITELIST_ENABLED` | bool | `true` | Enables/disables the Tcl command whitelist |
@@ -215,6 +218,41 @@ under the base directory. A symlink that points outside the base is caught here.
   (default 1568 px) above and `OPENROAD_IMAGE_MIN_DIMENSION` (default 512 px) below, and at most
   12 encode attempts. A caller raising `max_size_kb` raises the payload this server will emit;
   the 50 MB on-disk cap above still bounds what is read.
+
+### Flow-run execution policy
+
+`run_orfs_stage` spawns `make`, which `OPENROAD_ALLOWED_COMMANDS` does not cover — that setting
+gates the `openroad` binary for PTY sessions only. The flow runner therefore carries its own policy.
+
+**Target allowlist.** Only `synth`, `floorplan`, `place`, `cts`, `grt`, `route`, `finish`, `all`,
+`metadata` and the `clean_*` forms are accepted. This is not cosmetic: without it a `stage` value
+of `-f/tmp/evil.mk` reaches make as a *flag* rather than a goal, redirecting it to an attacker's
+makefile.
+
+**Override validation.** Keys must match `^[A-Z_][A-Z0-9_]*$`. These are refused regardless of
+value, because they control how make executes every recipe rather than what it builds:
+
+`SHELL`, `MAKESHELL`, `.SHELLFLAGS`, `MAKE`, `MAKEFLAGS`, `MAKEFILES`, `PATH`, `LD_PRELOAD`,
+`LD_LIBRARY_PATH`, `DYLD_INSERT_LIBRARIES`.
+
+Values are rejected if they contain newlines or null bytes (which would forge additional make
+arguments), or `$(`, `${` or a backtick. The last matters even though no shell is involved: **make
+expands `$(...)` when it reads a variable value**, so `FOO=$(shell id)` is a live execution path.
+
+**No shell.** The child is spawned with an argv array and `shell: false`, so an override value is
+one argument and is never re-parsed.
+
+**Process group.** Runs are spawned detached, into their own process group, so `cancel_orfs_job`,
+the timeout, and server shutdown can signal the whole tree. Killing only `make` would leave the
+`openroad` it spawned running — orphaned OpenROAD processes have been observed on this deployment.
+
+**Resource governance.** `OPENROAD_MAX_FLOW_JOBS` (default 2) caps concurrent runs, and
+`OPENROAD_FLOW_RUN_TIMEOUT` (default 6 h) bounds each one. A flow run is far heavier than an
+interactive session.
+
+**Still privileged.** `run_orfs_stage` writes into the ORFS flow tree and the `clean_*` targets
+delete results; it is annotated `destructiveHint: true`. The policy above constrains *what make is
+told to build*, not what the design's own configuration causes it to run.
 
 ### `read_orfs_metrics` path handling
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -163,6 +163,8 @@ All variables are read at startup by [`typescript/src/config/settings.ts`](../ty
 | `OPENROAD_IMAGE_MAX_BASE64_KB` | integer (KB) | `1024` | Report-image payload budget; override per-call with `max_size_kb` |
 | `OPENROAD_IMAGE_MAX_DIMENSION` | integer (pixels) | `1568` | Longest edge an image is capped to before encoding |
 | `OPENROAD_IMAGE_MIN_DIMENSION` | integer (pixels) | `512` | Floor below which the resize ladder will not shrink |
+| `OPENROAD_OUTPUT_HISTORY_CHARS` | integer (chars) | `262144` (256 KB) | Recent command output retained per session for `grep_session_output`; `0` disables |
+| `OPENROAD_OUTPUT_HISTORY_COMMANDS` | integer | `50` | Commands of output retained per session; `0` disables |
 | `OPENROAD_MAX_FLOW_JOBS` | integer | `2` | Concurrent `run_orfs_stage` runs allowed |
 | `OPENROAD_FLOW_RUN_TIMEOUT` | float (seconds) | `21600` (6 h) | Default wall-clock budget for a flow run |
 | `OPENROAD_RUN_LOG_DIR` | path | `<tmpdir>/openroad-mcp-runs` | Where flow-run logs are streamed |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -160,6 +160,9 @@ All variables are read at startup by [`typescript/src/config/settings.ts`](../ty
 | `OPENROAD_SESSION_QUEUE_SIZE` | integer | `128` | Maximum pending commands in input queue |
 | `OPENROAD_SESSION_IDLE_TIMEOUT` | float (seconds) | `300.0` | Idle threshold; does **not** trigger automatic cleanup (see [Session Lifecycle Notes](API.md#session-lifecycle-notes)) |
 | `OPENROAD_READ_CHUNK_SIZE` | integer (bytes) | `8192` | Max chunk size when splitting large PTY bursts |
+| `OPENROAD_IMAGE_MAX_BASE64_KB` | integer (KB) | `1024` | Report-image payload budget; override per-call with `max_size_kb` |
+| `OPENROAD_IMAGE_MAX_DIMENSION` | integer (pixels) | `1568` | Longest edge an image is capped to before encoding |
+| `OPENROAD_IMAGE_MIN_DIMENSION` | integer (pixels) | `512` | Floor below which the resize ladder will not shrink |
 | `OPENROAD_ALLOWED_COMMANDS` | string (comma-separated) | `openroad` | PTY spawn executable allowlist |
 | `OPENROAD_ENABLE_COMMAND_VALIDATION` | bool | `true` | Enables/disables `PtyHandler.validateCommand` |
 | `OPENROAD_WHITELIST_ENABLED` | bool | `true` | Enables/disables the Tcl command whitelist |
@@ -206,8 +209,12 @@ under the base directory. A symlink that points outside the base is caught here.
   `image_name` that does not end in one of them.
 - Symlinks are skipped during directory listing.
 - On-disk file size is capped at 50 MB before any decoding.
-- The base64-encoded payload is targeted at 15 KB; larger images are downscaled using sharp
-  (lanczos3, WebP quality 85, minimum dimension 256 px).
+- The base64 payload is budgeted at `OPENROAD_IMAGE_MAX_BASE64_KB` (default 1024 KB), which a
+  caller may override per-call with `max_size_kb`. An image over budget is downscaled with sharp
+  (lanczos3, WebP quality 85 → 70 → 55) along a ladder bounded by `OPENROAD_IMAGE_MAX_DIMENSION`
+  (default 1568 px) above and `OPENROAD_IMAGE_MIN_DIMENSION` (default 512 px) below, and at most
+  12 encode attempts. A caller raising `max_size_kb` raises the payload this server will emit;
+  the 50 MB on-disk cap above still bounds what is read.
 
 **Known image filename mappings:**
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -49,6 +49,7 @@ for per-client configuration for Cursor, Claude Code, GitHub Copilot, and 25+ ot
 | `get_session_metrics` | Aggregate metrics across all sessions |
 | `list_report_images` | List `.webp` report images from an ORFS run |
 | `read_report_image` | Read a report image and return it as a viewable image block |
+| `grep_session_output` | Search output of commands already run in a session |
 | `read_orfs_metrics` | Read a design's per-stage metrics, rules-base gates and log diagnostics |
 | `run_orfs_stage` | Run an ORFS flow stage via make as a tracked background job |
 | `get_orfs_job` | Poll a flow run: progress, log tail, and metrics once it finishes |

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -50,6 +50,9 @@ for per-client configuration for Cursor, Claude Code, GitHub Copilot, and 25+ ot
 | `list_report_images` | List `.webp` report images from an ORFS run |
 | `read_report_image` | Read a report image and return it as a viewable image block |
 | `read_orfs_metrics` | Read a design's per-stage metrics, rules-base gates and log diagnostics |
+| `run_orfs_stage` | Run an ORFS flow stage via make as a tracked background job |
+| `get_orfs_job` | Poll a flow run: progress, log tail, and metrics once it finishes |
+| `cancel_orfs_job` | Terminate a flow run and every process it spawned |
 
 Full parameter reference and wire-format shapes: [docs/API.md](https://github.com/The-OpenROAD-Project/openroad-mcp/blob/main/docs/API.md)
 
@@ -86,6 +89,7 @@ The server reads configuration from environment variables. Key variables:
 | `ORFS_FLOW_PATH` | `~/OpenROAD-flow-scripts/flow` (auto-detected if unset) | Path to ORFS flow directory |
 | `OPENROAD_WHITELIST_ENABLED` | `true` | Enable Tcl command whitelist |
 | `OPENROAD_IMAGE_MAX_BASE64_KB` | `1024` | Report-image payload budget in KB of base64 |
+| `OPENROAD_MAX_FLOW_JOBS` | `2` | Concurrent `run_orfs_stage` runs |
 
 Full list: [docs/SECURITY.md#environment-variable-reference](https://github.com/The-OpenROAD-Project/openroad-mcp/blob/main/docs/SECURITY.md#environment-variable-reference)
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -48,7 +48,8 @@ for per-client configuration for Cursor, Claude Code, GitHub Copilot, and 25+ ot
 | `get_session_history` | Command history with optional limit and search |
 | `get_session_metrics` | Aggregate metrics across all sessions |
 | `list_report_images` | List `.webp` report images from an ORFS run |
-| `read_report_image` | Read and base64-encode a single report image |
+| `read_report_image` | Read a report image and return it as a viewable image block |
+| `read_orfs_metrics` | Read a design's per-stage metrics, rules-base gates and log diagnostics |
 
 Full parameter reference and wire-format shapes: [docs/API.md](https://github.com/The-OpenROAD-Project/openroad-mcp/blob/main/docs/API.md)
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -84,6 +84,7 @@ The server reads configuration from environment variables. Key variables:
 | `OPENROAD_COMMAND_TIMEOUT` | `30.0` | Default per-command timeout in seconds |
 | `ORFS_FLOW_PATH` | `~/OpenROAD-flow-scripts/flow` (auto-detected if unset) | Path to ORFS flow directory |
 | `OPENROAD_WHITELIST_ENABLED` | `true` | Enable Tcl command whitelist |
+| `OPENROAD_IMAGE_MAX_BASE64_KB` | `1024` | Report-image payload budget in KB of base64 |
 
 Full list: [docs/SECURITY.md#environment-variable-reference](https://github.com/The-OpenROAD-Project/openroad-mcp/blob/main/docs/SECURITY.md#environment-variable-reference)
 

--- a/typescript/__tests__/config/command_whitelist.test.ts
+++ b/typescript/__tests__/config/command_whitelist.test.ts
@@ -337,6 +337,31 @@ describe("isExecCommand", () => {
     expect(isExecCommand("quit")).toEqual([false, "quit"]);
   });
 
+  it("blocks a bare gui::show, which wedges the session on the Tcl event loop", () => {
+    expect(isExecCommand("gui::show")).toEqual([false, "gui::show"]);
+  });
+
+  it("blocks a gui::show left interactive, since that also waits on a human", () => {
+    // `interactive` defaults to true, so omitting the flag blocks exactly as
+    // passing true does.
+    expect(isExecCommand("gui::show {save_image /tmp/a.png}")).toEqual([false, "gui::show"]);
+    expect(isExecCommand("gui::show {save_image /tmp/a.png} true")).toEqual([false, "gui::show"]);
+  });
+
+  it("allows the non-interactive gui::show that ORFS uses to render images", () => {
+    // This form runs the script inside a transient GUI event loop and returns,
+    // so it works headlessly under QT_QPA_PLATFORM=offscreen. Blocking it
+    // would remove the only way to capture a timing-path overlay.
+    expect(
+      isExecCommand("gui::show {gui::show_worst_path; save_image /tmp/worst.png} false"),
+    ).toEqual([true, null]);
+    expect(isExecCommand('gui::show "source save_images.tcl" false')).toEqual([true, null]);
+  });
+
+  it("blocks a bare gui::show hidden after another statement", () => {
+    expect(isExecCommand("read_db design.odb\ngui::show")).toEqual([false, "gui::show"]);
+  });
+
   it("allows a multiline all-allowed command", () => {
     expect(isExecCommand("read_db design.odb\nglobal_placement\nwrite_db out.odb")).toEqual([true, null]);
   });

--- a/typescript/__tests__/core/flow_jobs.test.ts
+++ b/typescript/__tests__/core/flow_jobs.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 
 vi.mock("../../src/config/settings.js", () => {
   const state = { runLogDir: "", maxJobs: 2, flowTimeout: 3600, flowPath: "" };
@@ -53,6 +54,49 @@ function stub(name: string, body: string): string {
   fs.writeFileSync(file, `#!/bin/sh\n${body}\n`);
   fs.chmodSync(file, 0o755);
   return file;
+}
+
+/**
+ * True when a pid is gone, or is a zombie -- which is dead, just not yet
+ * reaped.
+ *
+ * `process.kill(pid, 0)` only asks whether the pid resolves, not whether it is
+ * running. When the spawner dies with the process group, its child is
+ * reparented to PID 1; in a container PID 1 often does not reap, so the killed
+ * process lingers as a zombie and stays signalable indefinitely. Treating that
+ * as "still alive" is what fails in Docker while passing on a desktop.
+ */
+function isTerminated(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+  } catch {
+    return true;
+  }
+  try {
+    // Linux: field 3 of /proc/<pid>/stat, after the parenthesised comm.
+    const stat = fs.readFileSync(`/proc/${pid}/stat`, "utf8");
+    return stat.slice(stat.lastIndexOf(")") + 2).split(" ")[0] === "Z";
+  } catch {
+    /* not Linux, or the process vanished between calls */
+  }
+  try {
+    const state = execFileSync("ps", ["-o", "state=", "-p", String(pid)], {
+      encoding: "utf8",
+    }).trim();
+    return state === "" || state.startsWith("Z");
+  } catch {
+    return true;
+  }
+}
+
+/** Poll until the process has actually stopped running, or give up. */
+async function waitForTermination(pid: number, timeoutMs = 8000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (isTerminated(pid)) return true;
+    if (Date.now() >= deadline) return false;
+    await new Promise((r) => setTimeout(r, 100));
+  }
 }
 
 /** Wait until the job leaves `running`, or fail the test. */
@@ -254,9 +298,9 @@ describe("FlowJobRegistry teardown", () => {
     registry.cancel(job.jobId);
     await settle(registry, job.jobId, 10000);
 
-    // Give the signal a moment to land on the group.
-    await new Promise((r) => setTimeout(r, 300));
-    expect(() => process.kill(grandchildPid, 0)).toThrow();
+    // Poll rather than sleep a fixed interval: teardown escalates to SIGKILL
+    // after a grace period, and a loaded CI container is slower than a desktop.
+    expect(await waitForTermination(grandchildPid)).toBe(true);
   });
 
   it("marks a cancelled run cancelled, not failed", async () => {

--- a/typescript/__tests__/core/flow_jobs.test.ts
+++ b/typescript/__tests__/core/flow_jobs.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+vi.mock("../../src/config/settings.js", () => {
+  const state = { runLogDir: "", maxJobs: 2, flowTimeout: 3600, flowPath: "" };
+  return {
+    getSettings: vi.fn(() => ({
+      LOG_LEVEL: "SILENT",
+      RUN_LOG_DIR: state.runLogDir,
+      MAX_FLOW_JOBS: state.maxJobs,
+      FLOW_RUN_TIMEOUT: state.flowTimeout,
+      flowPath: state.flowPath,
+    })),
+    __state: state,
+  };
+});
+
+import { getSettings } from "../../src/config/settings.js";
+import { FlowJobRegistry, FlowJobLimitError, buildMakeArgv } from "../../src/core/flow_jobs.js";
+import type { FlowJobSpec } from "../../src/core/flow_jobs.js";
+
+let tmpDir: string;
+let registry: FlowJobRegistry;
+
+function setSettings(over: Partial<{ MAX_FLOW_JOBS: number; FLOW_RUN_TIMEOUT: number }> = {}): void {
+  (getSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+    LOG_LEVEL: "SILENT",
+    RUN_LOG_DIR: path.join(tmpDir, "runs"),
+    MAX_FLOW_JOBS: over.MAX_FLOW_JOBS ?? 2,
+    FLOW_RUN_TIMEOUT: over.FLOW_RUN_TIMEOUT ?? 3600,
+    flowPath: tmpDir,
+  });
+}
+
+function spec(over: Partial<FlowJobSpec> = {}): FlowJobSpec {
+  return {
+    platform: "nangate45", design: "gcd", variant: "base",
+    target: "cts", overrides: {}, ...over,
+  };
+}
+
+/**
+ * Write an executable stub standing in for `make`.
+ *
+ * Real binaries are a poor stand-in: `sleep` rejects make's argv, and `false`
+ * is not at the same path on every OS. A stub ignores its arguments and does
+ * exactly what the test needs.
+ */
+function stub(name: string, body: string): string {
+  const file = path.join(tmpDir, name);
+  fs.writeFileSync(file, `#!/bin/sh\n${body}\n`);
+  fs.chmodSync(file, 0o755);
+  return file;
+}
+
+/** Wait until the job leaves `running`, or fail the test. */
+async function settle(reg: FlowJobRegistry, jobId: string, ms = 8000) {
+  const job = await reg.waitFor(jobId, ms);
+  expect(job.status).not.toBe("running");
+  return job;
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "flow-jobs-test-"));
+  setSettings();
+});
+
+afterEach(async () => {
+  await registry?.shutdown();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+describe("buildMakeArgv", () => {
+  it("puts overrides on the command line, where they beat env and the Makefile", () => {
+    const argv = buildMakeArgv(spec({ overrides: { PLACE_DENSITY_LB_ADDON: "0.25" } }));
+
+    expect(argv).toContain("cts");
+    expect(argv).toContain("DESIGN_CONFIG=./designs/nangate45/gcd/config.mk");
+    expect(argv).toContain("FLOW_VARIANT=base");
+    expect(argv).toContain("PLACE_DENSITY_LB_ADDON=0.25");
+  });
+
+  it("keeps each assignment a single argv entry, never a shell string", () => {
+    const argv = buildMakeArgv(spec({ overrides: { CTS_BUF_LIST: "CLKBUF_X2 CLKBUF_X4" } }));
+
+    expect(argv).toContain("CTS_BUF_LIST=CLKBUF_X2 CLKBUF_X4");
+  });
+
+  it("passes -n for a dry run and -j for parallelism", () => {
+    const argv = buildMakeArgv(spec({ dryRun: true, jobs: 8 }));
+
+    expect(argv[0]).toBe("-n");
+    expect(argv).toContain("-j8");
+  });
+});
+
+describe("FlowJobRegistry lifecycle", () => {
+  it("records a successful run with its exit code and log on disk", async () => {
+    registry = new FlowJobRegistry(stub("quick.sh", "echo cts done"));
+    const job = registry.start(spec(), tmpDir);
+
+    const done = await settle(registry, job.jobId);
+
+    expect(done.status).toBe("succeeded");
+    expect(done.exitCode).toBe(0);
+    expect(fs.existsSync(done.logPath)).toBe(true);
+    expect(fs.readFileSync(done.logPath, "utf8")).toContain("cts");
+  });
+
+  it("records the real exit code of a failing run", async () => {
+    registry = new FlowJobRegistry(stub("fails.sh", "exit 3"));
+    const job = registry.start(spec(), tmpDir);
+
+    const done = await settle(registry, job.jobId);
+
+    expect(done.status).toBe("failed");
+    expect(done.exitCode).toBe(3);
+  });
+
+  it("writes a status file mirroring the .orfs-eval-logs convention", async () => {
+    registry = new FlowJobRegistry(stub("quick.sh", "echo cts done"));
+    const job = registry.start(spec(), tmpDir);
+    await settle(registry, job.jobId);
+
+    const status = fs.readFileSync(job.statusPath, "utf8");
+    expect(status).toContain("RC=0");
+    expect(status).toContain("STATUS=succeeded");
+  });
+
+  it("reports a spawn failure rather than hanging as running", async () => {
+    registry = new FlowJobRegistry(path.join(tmpDir, "no-such-binary"));
+    const job = registry.start(spec(), tmpDir);
+
+    const done = await settle(registry, job.jobId);
+
+    expect(done.status).toBe("failed");
+    expect(done.error).toBeTruthy();
+  });
+
+  it("streams to a file, not through a bounded buffer", async () => {
+    // A route log runs to tens of MB; the 128 KB session buffer would keep
+    // only the tail.
+    registry = new FlowJobRegistry(stub("chatty.sh", "i=0; while [ $i -lt 500 ]; do echo \"line $i\"; i=$((i+1)); done"));
+    const job = registry.start(spec({ target: "route" }), tmpDir);
+    await settle(registry, job.jobId);
+
+    const bytes = fs.statSync(job.logPath).size;
+    // Comfortably past what a 128 KB circular buffer would have kept of a
+    // real route log, and every byte is on disk.
+    expect(bytes).toBeGreaterThan(3000);
+    const view = registry.inspect(job.jobId, 5);
+    expect(view.logBytes).toBe(bytes);
+  });
+
+  it("returns a running job immediately when the caller does not wait", () => {
+    registry = new FlowJobRegistry(stub("slow.sh", "sleep 300"));
+    const job = registry.start(spec(), tmpDir);
+
+    expect(job.status).toBe("running");
+    expect(job.jobId).toHaveLength(8);
+    expect(job.pid).toBeGreaterThan(0);
+  });
+
+  it("waitFor gives up after its budget rather than blocking on a long run", async () => {
+    registry = new FlowJobRegistry(stub("slow.sh", "sleep 300"));
+    const job = registry.start(spec(), tmpDir);
+
+    const still = await registry.waitFor(job.jobId, 150);
+
+    expect(still.status).toBe("running");
+  });
+
+  it("enforces the concurrency cap", () => {
+    setSettings({ MAX_FLOW_JOBS: 1 });
+    registry = new FlowJobRegistry(stub("slow.sh", "sleep 300"));
+    registry.start(spec(), tmpDir);
+
+    expect(() => registry.start(spec(), tmpDir)).toThrow(FlowJobLimitError);
+  });
+
+  it("counts a finished job as no longer active", async () => {
+    setSettings({ MAX_FLOW_JOBS: 1 });
+    registry = new FlowJobRegistry(stub("quick.sh", "echo cts done"));
+    const first = registry.start(spec(), tmpDir);
+    await settle(registry, first.jobId);
+
+    expect(registry.activeCount()).toBe(0);
+    expect(() => registry.start(spec(), tmpDir)).not.toThrow();
+  });
+
+  it("times out a run that overruns its budget", async () => {
+    setSettings({ FLOW_RUN_TIMEOUT: 3600 });
+    registry = new FlowJobRegistry(stub("slow.sh", "sleep 300"));
+    const job = registry.start(spec({ timeoutSeconds: 1 }), tmpDir);
+
+    const done = await settle(registry, job.jobId, 10000);
+
+    expect(done.status).toBe("timed_out");
+    expect(done.error).toMatch(/exceeded 1s/);
+  });
+});
+
+describe("FlowJobRegistry teardown", () => {
+  it("kills the whole process group, leaving no orphaned grandchild", async () => {
+    // The orphan case scenario 10 found on this host: killing only `make`
+    // strands the openroad it spawned. The run must go down as a group.
+    const marker = path.join(tmpDir, "grandchild.pid");
+    const script = path.join(tmpDir, "spawner.sh");
+    fs.writeFileSync(
+      script,
+      `#!/bin/sh\nsleep 300 &\necho $! > ${marker}\nwait\n`,
+    );
+    fs.chmodSync(script, 0o755);
+
+    registry = new FlowJobRegistry(script);
+    const job = registry.start(spec(), tmpDir);
+
+    // Wait for the grandchild to exist.
+    for (let i = 0; i < 100 && !fs.existsSync(marker); i += 1) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    const grandchildPid = Number(fs.readFileSync(marker, "utf8").trim());
+    expect(grandchildPid).toBeGreaterThan(0);
+    expect(() => process.kill(grandchildPid, 0)).not.toThrow();
+
+    registry.cancel(job.jobId);
+    await settle(registry, job.jobId, 10000);
+
+    // Give the signal a moment to land on the group.
+    await new Promise((r) => setTimeout(r, 300));
+    expect(() => process.kill(grandchildPid, 0)).toThrow();
+  });
+
+  it("marks a cancelled run cancelled, not failed", async () => {
+    registry = new FlowJobRegistry(stub("slow.sh", "sleep 300"));
+    const job = registry.start(spec(), tmpDir);
+
+    registry.cancel(job.jobId);
+    const done = await settle(registry, job.jobId, 10000);
+
+    expect(done.status).toBe("cancelled");
+  });
+
+  it("cancelling a finished job is a no-op", async () => {
+    registry = new FlowJobRegistry(stub("quick.sh", "echo cts done"));
+    const job = registry.start(spec(), tmpDir);
+    await settle(registry, job.jobId);
+
+    expect(registry.cancel(job.jobId).status).toBe("succeeded");
+  });
+
+  it("shutdown terminates every running job", async () => {
+    registry = new FlowJobRegistry(stub("slow.sh", "sleep 300"));
+    const job = registry.start(spec(), tmpDir);
+
+    await registry.shutdown();
+    const done = await settle(registry, job.jobId, 10000);
+
+    expect(done.status).toBe("cancelled");
+  });
+});
+
+describe("FlowJobRegistry.inspect", () => {
+  it("surfaces progress parsed from the streaming log", async () => {
+    registry = new FlowJobRegistry(stub("quick.sh", "echo cts done"));
+    const job = registry.start(spec({ target: "route" }), tmpDir);
+    await settle(registry, job.jobId);
+
+    fs.appendFileSync(
+      job.logPath,
+      [
+        "[INFO DRT-0195] Start 1st optimization iteration.",
+        "    Completing 80% with 19604 violations.",
+        "[INFO DRT-0267] cpu time = 00:30:00, elapsed time = 00:10:00, memory = 4210.5 (MB), peak = 4300.0 (MB)",
+      ].join("\n"),
+    );
+    fs.mkdirSync(job.logsDir, { recursive: true });
+    fs.writeFileSync(path.join(job.logsDir, "5_2_route.tmp.log"), "x");
+
+    const view = registry.inspect(job.jobId, 10);
+
+    expect(view.progress.currentStage).toBe("5_2_route");
+    expect(view.progress.iteration).toBe(1);
+    expect(view.progress.violations).toBe(19604);
+    expect(view.progress.cpuSeconds).toBe(1800);
+    expect(view.progress.memoryMb).toBe(4210.5);
+  });
+
+  it("reports elapsed time and stops the clock when the job finishes", async () => {
+    registry = new FlowJobRegistry(stub("quick.sh", "echo cts done"));
+    const job = registry.start(spec(), tmpDir);
+    await settle(registry, job.jobId);
+
+    const first = registry.inspect(job.jobId).elapsedSeconds;
+    await new Promise((r) => setTimeout(r, 120));
+    expect(registry.inspect(job.jobId).elapsedSeconds).toBe(first);
+  });
+});

--- a/typescript/__tests__/core/flow_jobs.test.ts
+++ b/typescript/__tests__/core/flow_jobs.test.ts
@@ -191,9 +191,12 @@ describe("FlowJobRegistry lifecycle", () => {
     const job = registry.start(spec({ target: "route" }), tmpDir);
     await settle(registry, job.jobId);
 
+    // The whole log must be on disk by the time the job reports finished: a
+    // caller that polls immediately must not get a partial file.
+    const body = fs.readFileSync(job.logPath, "utf8");
+    expect(body).toContain("line 0");
+    expect(body).toContain("line 499");
     const bytes = fs.statSync(job.logPath).size;
-    // Comfortably past what a 128 KB circular buffer would have kept of a
-    // real route log, and every byte is on disk.
     expect(bytes).toBeGreaterThan(3000);
     const view = registry.inspect(job.jobId, 5);
     expect(view.logBytes).toBe(bytes);

--- a/typescript/__tests__/core/flow_jobs.test.ts
+++ b/typescript/__tests__/core/flow_jobs.test.ts
@@ -203,6 +203,31 @@ describe("FlowJobRegistry lifecycle", () => {
   });
 });
 
+describe("FlowJobRegistry log durability", () => {
+  it("survives the run log becoming unwritable mid-run", async () => {
+    // The log stream opens asynchronously, so a log directory that disappears
+    // after the run starts surfaces as a stream error. With no listener that is
+    // an uncaught exception, which would take the whole server down over a
+    // lost log file. The run must outlive its log.
+    registry = new FlowJobRegistry(stub("quick.sh", "echo cts done"));
+    const job = registry.start(spec(), tmpDir);
+    fs.rmSync(path.join(tmpDir, "runs"), { recursive: true, force: true });
+
+    const done = await settle(registry, job.jobId, 10000);
+
+    expect(done.status).toBe("succeeded");
+    expect(done.exitCode).toBe(0);
+  });
+
+  it("reports the log as writable on a healthy run", async () => {
+    registry = new FlowJobRegistry(stub("quick.sh", "echo ok"));
+    const job = registry.start(spec(), tmpDir);
+    await settle(registry, job.jobId);
+
+    expect(job.logWritable).toBe(true);
+  });
+});
+
 describe("FlowJobRegistry teardown", () => {
   it("kills the whole process group, leaving no orphaned grandchild", async () => {
     // The orphan case scenario 10 found on this host: killing only `make`

--- a/typescript/__tests__/flow/run_progress.test.ts
+++ b/typescript/__tests__/flow/run_progress.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  parseRunProgress,
+  detectCurrentStage,
+  readLogTail,
+  readLogTailText,
+} from "../../src/flow/run_progress.js";
+
+/** Verbatim excerpt from scenario 8's ibex detailed-route log. */
+const ROUTE_TAIL = [
+  "[INFO DRT-0194] Start detail routing.",
+  "[INFO DRT-0195] Start 0th optimization iteration.",
+  "    Completing 10% with 0 violations.",
+  "    Completing 100% with 20 violations.",
+  "[INFO DRT-0199]   Number of violations = 20.",
+  "[INFO DRT-0195] Start 1st optimization iteration.",
+  "    Completing 70% with 22421 violations.",
+  "    Completing 80% with 19604 violations.",
+  "[INFO DRT-0267] cpu time = 00:00:13, elapsed time = 00:00:04, memory = 557.72 (MB), peak = 570.05 (MB)",
+].join("\n");
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "run-progress-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("parseRunProgress", () => {
+  it("reads iteration, percent and live violation count from a real route tail", () => {
+    const p = parseRunProgress(ROUTE_TAIL, "5_2_route");
+
+    expect(p.currentStage).toBe("5_2_route");
+    expect(p.iteration).toBe(1);
+    expect(p.percent).toBe(80);
+    expect(p.violations).toBe(19604);
+  });
+
+  it("keeps the violation total reported at the end of an iteration", () => {
+    expect(parseRunProgress(ROUTE_TAIL, null).iterationViolations).toBe(20);
+  });
+
+  it("takes cpu and memory from OpenROAD's own resource line", () => {
+    // pidusage on the make pid would miss this entirely: the process burning
+    // the machine is a grandchild openroad.
+    const p = parseRunProgress(ROUTE_TAIL, null);
+
+    expect(p.cpuSeconds).toBe(13);
+    expect(p.elapsedSeconds).toBe(4);
+    expect(p.memoryMb).toBe(557.72);
+    expect(p.peakMemoryMb).toBe(570.05);
+  });
+
+  it("parses hours in the resource line, not just seconds", () => {
+    const p = parseRunProgress(
+      "[INFO DRT-0267] cpu time = 02:15:30, elapsed time = 01:05:00, memory = 4210.5 (MB), peak = 4300.0 (MB)",
+      null,
+    );
+
+    expect(p.cpuSeconds).toBe(2 * 3600 + 15 * 60 + 30);
+    expect(p.elapsedSeconds).toBe(3900);
+    expect(p.memoryMb).toBe(4210.5);
+  });
+
+  it("always reports the most recent value, not the first", () => {
+    const p = parseRunProgress(ROUTE_TAIL, null);
+    expect(p.percent).toBe(80);
+    expect(p.violations).toBe(19604);
+    expect(p.iteration).toBe(1);
+  });
+
+  it("returns nulls rather than guesses for a log with no progress markers", () => {
+    const p = parseRunProgress("make: Entering directory '/flow'\nnothing here\n", null);
+
+    expect(p.iteration).toBeNull();
+    expect(p.percent).toBeNull();
+    expect(p.violations).toBeNull();
+    expect(p.cpuSeconds).toBeNull();
+  });
+});
+
+describe("detectCurrentStage", () => {
+  it("names the stage whose .tmp.log is newest", () => {
+    fs.writeFileSync(path.join(tmpDir, "5_1_grt.log"), "done");
+    fs.writeFileSync(path.join(tmpDir, "5_2_route.tmp.log"), "running");
+
+    expect(detectCurrentStage(tmpDir)).toBe("5_2_route");
+  });
+
+  it("follows the flow as a newer stage starts", () => {
+    const older = path.join(tmpDir, "5_1_grt.tmp.log");
+    fs.writeFileSync(older, "x");
+    fs.utimesSync(older, new Date(Date.now() - 60_000), new Date(Date.now() - 60_000));
+    fs.writeFileSync(path.join(tmpDir, "5_2_route.tmp.log"), "y");
+
+    expect(detectCurrentStage(tmpDir)).toBe("5_2_route");
+  });
+
+  it("ignores completed stages, whose logs are no longer .tmp", () => {
+    fs.writeFileSync(path.join(tmpDir, "4_1_cts.log"), "done");
+    fs.writeFileSync(path.join(tmpDir, "4_1_cts.json"), "{}");
+
+    expect(detectCurrentStage(tmpDir)).toBeNull();
+  });
+
+  it("returns null for a directory that does not exist", () => {
+    expect(detectCurrentStage(path.join(tmpDir, "nope"))).toBeNull();
+  });
+});
+
+describe("readLogTail", () => {
+  it("returns the last lines and reports the true total size", () => {
+    const logPath = path.join(tmpDir, "run.log");
+    const body = Array.from({ length: 500 }, (_, i) => `line ${i}`).join("\n");
+    fs.writeFileSync(logPath, body);
+
+    const tail = readLogTail(logPath, 10);
+
+    expect(tail.lines).toHaveLength(10);
+    expect(tail.lines[9]).toBe("line 499");
+    expect(tail.totalBytes).toBe(Buffer.byteLength(body));
+    expect(tail.truncated).toBe(true);
+  });
+
+  it("is not truncated when the whole log fits", () => {
+    const logPath = path.join(tmpDir, "small.log");
+    fs.writeFileSync(logPath, "one\ntwo\nthree");
+
+    const tail = readLogTail(logPath, 50);
+
+    expect(tail.lines).toEqual(["one", "two", "three"]);
+    expect(tail.truncated).toBe(false);
+  });
+
+  it("drops a partial first line rather than returning a fragment", () => {
+    // The tail read starts at a byte offset, which lands mid-line on any large
+    // log; a half line presented as a whole one is the same class of bug as
+    // silent output truncation.
+    const logPath = path.join(tmpDir, "big.log");
+    const line = "x".repeat(1000);
+    fs.writeFileSync(logPath, Array.from({ length: 200 }, () => line).join("\n"));
+
+    const tail = readLogTail(logPath, 5);
+
+    expect(tail.truncated).toBe(true);
+    for (const l of tail.lines) expect(l).toHaveLength(1000);
+  });
+
+  it("returns empty for a missing log instead of throwing", () => {
+    const tail = readLogTail(path.join(tmpDir, "absent.log"));
+
+    expect(tail.lines).toEqual([]);
+    expect(tail.totalBytes).toBe(0);
+  });
+
+  it("feeds the progress parser end to end", () => {
+    const logPath = path.join(tmpDir, "route.log");
+    fs.writeFileSync(logPath, ROUTE_TAIL);
+
+    const p = parseRunProgress(readLogTailText(logPath), null);
+
+    expect(p.violations).toBe(19604);
+    expect(p.iteration).toBe(1);
+  });
+});

--- a/typescript/__tests__/golden/fixture_helpers.ts
+++ b/typescript/__tests__/golden/fixture_helpers.ts
@@ -115,7 +115,10 @@ export const cases: Record<string, () => unknown> = {
       timestamp: TS,
       executionTime: 1.5,
       commandCount: 3,
-      bufferSize: 2048,
+      bufferSize: 131072,
+      truncated: false,
+      bytesDiscarded: 0,
+      totalBytes: 13,
       error: null,
     };
     return toSnakeCase(r);
@@ -128,6 +131,9 @@ export const cases: Record<string, () => unknown> = {
       executionTime: 0.0,
       commandCount: 0,
       bufferSize: 0,
+      truncated: false,
+      bytesDiscarded: 0,
+      totalBytes: 0,
       error: "CommandBlocked: 'exit'",
     };
     return toSnakeCase(r);

--- a/typescript/__tests__/golden/fixtures/interactive_exec_result_error.json
+++ b/typescript/__tests__/golden/fixtures/interactive_exec_result_error.json
@@ -5,5 +5,8 @@
   "execution_time": 0,
   "command_count": 0,
   "buffer_size": 0,
+  "truncated": false,
+  "bytes_discarded": 0,
+  "total_bytes": 0,
   "error": "CommandBlocked: 'exit'"
 }

--- a/typescript/__tests__/golden/fixtures/interactive_exec_result_success.json
+++ b/typescript/__tests__/golden/fixtures/interactive_exec_result_success.json
@@ -4,6 +4,9 @@
   "timestamp": "2026-01-01T00:00:00",
   "execution_time": 1.5,
   "command_count": 3,
-  "buffer_size": 2048,
+  "buffer_size": 131072,
+  "truncated": false,
+  "bytes_discarded": 0,
+  "total_bytes": 13,
   "error": null
 }

--- a/typescript/__tests__/golden/fixtures/tool_manifest.json
+++ b/typescript/__tests__/golden/fixtures/tool_manifest.json
@@ -149,6 +149,32 @@
       "openWorldHint": false
     }
   },
+  "read_orfs_metrics": {
+    "params": {
+      "design": {
+        "type": "string",
+        "required": true
+      },
+      "stage": {
+        "type": "string",
+        "required": false
+      },
+      "platform": {
+        "type": "string",
+        "required": false
+      },
+      "variant": {
+        "type": "string",
+        "required": false
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false
+    }
+  },
   "read_report_image": {
     "params": {
       "platform": {

--- a/typescript/__tests__/golden/fixtures/tool_manifest.json
+++ b/typescript/__tests__/golden/fixtures/tool_manifest.json
@@ -166,6 +166,10 @@
       "image_name": {
         "type": "string",
         "required": true
+      },
+      "max_size_kb": {
+        "type": "integer",
+        "required": false
       }
     },
     "annotations": {

--- a/typescript/__tests__/golden/fixtures/tool_manifest.json
+++ b/typescript/__tests__/golden/fixtures/tool_manifest.json
@@ -88,6 +88,40 @@
       "openWorldHint": false
     }
   },
+  "grep_session_output": {
+    "params": {
+      "session_id": {
+        "type": "string",
+        "required": true
+      },
+      "pattern": {
+        "type": "string",
+        "required": true
+      },
+      "max_matches": {
+        "type": "integer",
+        "required": false
+      },
+      "context_lines": {
+        "type": "integer",
+        "required": false
+      },
+      "ignore_case": {
+        "type": "boolean",
+        "required": false
+      },
+      "command_number": {
+        "type": "integer",
+        "required": false
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false
+    }
+  },
   "inspect_interactive_session": {
     "params": {
       "session_id": {

--- a/typescript/__tests__/golden/fixtures/tool_manifest.json
+++ b/typescript/__tests__/golden/fixtures/tool_manifest.json
@@ -1,4 +1,18 @@
 {
+  "cancel_orfs_job": {
+    "params": {
+      "job_id": {
+        "type": "string",
+        "required": true
+      }
+    },
+    "annotations": {
+      "readOnlyHint": false,
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": false
+    }
+  },
   "create_interactive_session": {
     "params": {
       "session_id": {
@@ -22,6 +36,24 @@
       "readOnlyHint": false,
       "destructiveHint": false,
       "idempotentHint": false,
+      "openWorldHint": false
+    }
+  },
+  "get_orfs_job": {
+    "params": {
+      "job_id": {
+        "type": "string",
+        "required": false
+      },
+      "recent_lines": {
+        "type": "integer",
+        "required": false
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
       "openWorldHint": false
     }
   },
@@ -202,6 +234,52 @@
       "readOnlyHint": true,
       "destructiveHint": false,
       "idempotentHint": true,
+      "openWorldHint": false
+    }
+  },
+  "run_orfs_stage": {
+    "params": {
+      "design": {
+        "type": "string",
+        "required": true
+      },
+      "stage": {
+        "type": "string",
+        "required": true
+      },
+      "overrides": {
+        "type": "object",
+        "required": false
+      },
+      "platform": {
+        "type": "string",
+        "required": false
+      },
+      "variant": {
+        "type": "string",
+        "required": false
+      },
+      "wait_seconds": {
+        "type": "integer",
+        "required": false
+      },
+      "jobs": {
+        "type": "integer",
+        "required": false
+      },
+      "timeout_seconds": {
+        "type": "integer",
+        "required": false
+      },
+      "dry_run": {
+        "type": "boolean",
+        "required": false
+      }
+    },
+    "annotations": {
+      "readOnlyHint": false,
+      "destructiveHint": true,
+      "idempotentHint": false,
       "openWorldHint": false
     }
   },

--- a/typescript/__tests__/integration/pty_integration.test.ts
+++ b/typescript/__tests__/integration/pty_integration.test.ts
@@ -158,6 +158,11 @@ describe("PTY Integration", () => {
     );
     const code = await handler.waitForExit(10000);
     expect(code).toBe(0);
+    // Process exit and data delivery are separate events: the child can be
+    // reaped while its last chunks are still in flight, which on a fast runner
+    // leaves the collector nearly empty. Wait for the output the same way the
+    // other tests here do, rather than asserting the instant it exits.
+    await waitUntil(() => output().includes("line 100"), 5000);
     expect(output().length).toBeGreaterThan(1000);
     expect(output()).toContain("line 1");
     expect(output()).toContain("line 100");

--- a/typescript/__tests__/interactive/buffer.test.ts
+++ b/typescript/__tests__/interactive/buffer.test.ts
@@ -63,6 +63,68 @@ describe("CircularBuffer", () => {
     });
   });
 
+  describe("discard accounting", () => {
+    it("reports zero when nothing overflowed", async () => {
+      const buf = new CircularBuffer(100);
+      await buf.append("12345");
+
+      expect(buf.discardedChars).toBe(0);
+      expect(await buf.takeDiscarded()).toBe(0);
+    });
+
+    it("counts characters dropped when oldest chunks are evicted", async () => {
+      const buf = new CircularBuffer(10);
+      await buf.append("12345");
+      await buf.append("67890");
+      await buf.append("ABCDE");
+
+      // "12345" was evicted whole.
+      expect(buf.discardedChars).toBe(5);
+    });
+
+    it("counts characters shaved off a single oversized chunk", async () => {
+      const buf = new CircularBuffer(10);
+      await buf.append("LARGE_CHUNK_EXCEEDS");
+
+      // 19 characters in, 10 retained.
+      expect(buf.discardedChars).toBe(9);
+    });
+
+    it("accumulates across appends and survives a drain", async () => {
+      const buf = new CircularBuffer(10);
+      await buf.append("12345");
+      await buf.append("67890");
+      await buf.append("ABCDE");
+      await buf.drainAll();
+      await buf.append("FGHIJ");
+      await buf.append("KLMNO");
+      await buf.append("PQRST");
+
+      expect(buf.discardedChars).toBe(10);
+    });
+
+    it("takeDiscarded returns the count and resets it", async () => {
+      const buf = new CircularBuffer(10);
+      await buf.append("12345");
+      await buf.append("67890");
+      await buf.append("ABCDE");
+
+      expect(await buf.takeDiscarded()).toBe(5);
+      expect(buf.discardedChars).toBe(0);
+      expect(await buf.takeDiscarded()).toBe(0);
+    });
+
+    it("exposes the count through getStats", async () => {
+      const buf = new CircularBuffer(10);
+      await buf.append("12345");
+      await buf.append("67890");
+      await buf.append("ABCDE");
+
+      const stats = await buf.getStats();
+      expect(stats.discardedChars).toBe(5);
+    });
+  });
+
   describe("edge cases", () => {
     it("ignores empty string appends", async () => {
       const buf = new CircularBuffer(100);

--- a/typescript/__tests__/interactive/session.test.ts
+++ b/typescript/__tests__/interactive/session.test.ts
@@ -1012,3 +1012,201 @@ describe("InteractiveSession", () => {
     });
   });
 });
+
+describe("InteractiveSession output search", () => {
+  let session: InteractiveSession;
+
+  const NONCE_RE = /join \{ORMCP DONE (\S+)\}/;
+
+  function makePty(target: InteractiveSession, nextOutput: () => string): PtyHandler {
+    return {
+      isProcessAlive: vi.fn().mockReturnValue(true),
+      createSession: vi.fn().mockResolvedValue(undefined),
+      writeInput: vi.fn().mockImplementation((data: string) => {
+        void target.outputBuffer.append(data.replace(/\r$/, "\r\n"));
+        const m = NONCE_RE.exec(data);
+        if (!m) return;
+        setTimeout(() => {
+          void target.outputBuffer.append(nextOutput());
+          void target.outputBuffer.append(`ORMCP-DONE-${m[1]}\r\n`);
+        }, 5);
+      }),
+      terminateProcess: vi.fn().mockResolvedValue(undefined),
+      cleanup: vi.fn().mockResolvedValue(undefined),
+      waitForExit: vi.fn().mockResolvedValue(null),
+      validateCommand: vi.fn(),
+    } as unknown as PtyHandler;
+  }
+
+  beforeEach(async () => {
+    session = new InteractiveSession("grep-session", 65536);
+    session.pty = makePty(session, () => "");
+  });
+
+  afterEach(async () => {
+    await session.cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("finds output from a command that has already returned", async () => {
+    // The regression: runCommand drains the circular buffer to empty, so a
+    // search over the live buffer alone finds nothing once the command is done.
+    let out = "wns max -0.485\r\ntns max -12.3\r\n";
+    session.pty = makePty(session, () => out);
+    await session.start(["openroad"]);
+    const result = await session.runCommand("report_checks", 2000);
+    expect(result.output).toContain("wns max -0.485");
+
+    expect(session.outputBuffer.size).toBe(0);
+    const grep = await session.grepOutput("wns");
+
+    expect(grep.matches).toHaveLength(1);
+    expect(grep.matches[0]!.line).toContain("wns max -0.485");
+    expect(grep.matches[0]!.command).toBe("report_checks");
+  });
+
+  it("searches across several commands and attributes each match", async () => {
+    let out = "cts__timing__setup__ws 0.1\r\n";
+    session.pty = makePty(session, () => out);
+    await session.start(["openroad"]);
+    await session.runCommand("report_cts", 2000);
+    out = "finish__timing__setup__ws -0.4\r\n";
+    await session.runCommand("report_finish", 2000);
+
+    const grep = await session.grepOutput("setup__ws");
+
+    expect(grep.totalMatches).toBe(2);
+    expect(grep.searchedCommands).toBe(2);
+    expect(grep.matches.map((m) => m.command)).toEqual(["report_cts", "report_finish"]);
+    expect(grep.matches[0]!.commandNumber).not.toBe(grep.matches[1]!.commandNumber);
+  });
+
+  it("can be scoped to one command's output", async () => {
+    let out = "shared marker A\r\n";
+    session.pty = makePty(session, () => out);
+    await session.start(["openroad"]);
+    await session.runCommand("first", 2000);
+    out = "shared marker B\r\n";
+    await session.runCommand("second", 2000);
+
+    const all = await session.grepOutput("shared marker");
+    const scoped = await session.grepOutput("shared marker", {
+      commandNumber: all.matches[1]!.commandNumber,
+    });
+
+    expect(all.totalMatches).toBe(2);
+    expect(scoped.totalMatches).toBe(1);
+    expect(scoped.matches[0]!.command).toBe("second");
+  });
+
+  it("returns surrounding lines when context is requested", async () => {
+    let out = "row one\r\nrow two\r\nTARGET row\r\nrow four\r\nrow five\r\n";
+    session.pty = makePty(session, () => out);
+    await session.start(["openroad"]);
+    await session.runCommand("report_checks", 2000);
+
+    const grep = await session.grepOutput("TARGET", { contextLines: 2 });
+
+    expect(grep.matches[0]!.before).toEqual(["row one", "row two"]);
+    expect(grep.matches[0]!.after).toEqual(["row four", "row five"]);
+  });
+
+  it("reports its own capping instead of returning a capped list as the whole answer", async () => {
+    let out = Array.from({ length: 40 }, (_, i) => `slack path ${i}`).join("\r\n") + "\r\n";
+    session.pty = makePty(session, () => out);
+    await session.start(["openroad"]);
+    await session.runCommand("report_checks", 2000);
+
+    const grep = await session.grepOutput("slack path", { maxMatches: 5 });
+
+    expect(grep.matches).toHaveLength(5);
+    expect(grep.totalMatches).toBe(40);
+    expect(grep.truncated).toBe(true);
+  });
+
+  it("treats an uncompilable pattern as a literal rather than erroring", async () => {
+    let out = "net dpath.a_reg[0 loaded\r\n";
+    session.pty = makePty(session, () => out);
+    await session.start(["openroad"]);
+    await session.runCommand("report_net", 2000);
+
+    const grep = await session.grepOutput("dpath.a_reg[0");
+
+    expect(grep.patternKind).toBe("substring");
+    expect(grep.totalMatches).toBe(1);
+  });
+
+  it("retries literally when a valid regex matches nothing", async () => {
+    // `dpath.a_reg[0]` compiles fine but means "…a_reg followed by 0", so it
+    // matches nothing -- worse than a syntax error, because the caller is told
+    // there are no matches when it is the pattern that is wrong.
+    let out = "net dpath.a_reg[0] loaded\r\n";
+    session.pty = makePty(session, () => out);
+    await session.start(["openroad"]);
+    await session.runCommand("report_net", 2000);
+
+    const grep = await session.grepOutput("dpath.a_reg[0]");
+
+    expect(grep.patternKind).toBe("substring-fallback");
+    expect(grep.totalMatches).toBe(1);
+    expect(grep.matches[0]!.line).toContain("dpath.a_reg[0]");
+  });
+
+  it("does not fall back when the regex genuinely matches nothing", async () => {
+    let out = "nothing of interest here\r\n";
+    session.pty = makePty(session, () => out);
+    await session.start(["openroad"]);
+    await session.runCommand("report_net", 2000);
+
+    const grep = await session.grepOutput("wns.*slack");
+
+    expect(grep.patternKind).toBe("regex");
+    expect(grep.totalMatches).toBe(0);
+  });
+
+  it("honours case sensitivity when asked", async () => {
+    let out = "Error: bad\r\nerror: worse\r\n";
+    session.pty = makePty(session, () => out);
+    await session.start(["openroad"]);
+    await session.runCommand("report", 2000);
+
+    expect((await session.grepOutput("Error")).totalMatches).toBe(2);
+    expect((await session.grepOutput("Error", { ignoreCase: false })).totalMatches).toBe(1);
+  });
+
+  it("evicts the oldest output to stay inside the retention budget, and says so", async () => {
+    const settings = new Settings({ OUTPUT_HISTORY_COMMANDS: 2, OUTPUT_HISTORY_CHARS: 1_000_000 });
+    session = new InteractiveSession("evicting", 65536, settings);
+    let out = "marker one\r\n";
+    session.pty = makePty(session, () => out);
+    await session.start(["openroad"]);
+    await session.runCommand("first", 2000);
+    out = "marker two\r\n";
+    await session.runCommand("second", 2000);
+    out = "marker three\r\n";
+    await session.runCommand("third", 2000);
+
+    const grep = await session.grepOutput("marker");
+
+    expect(grep.totalMatches).toBe(2);
+    expect(grep.evictedCommands).toBe(1);
+    expect(grep.matches.map((m) => m.line.trim())).toEqual(["marker two", "marker three"]);
+  });
+
+  it("searches output still sitting unread in the buffer", async () => {
+    await session.outputBuffer.append("pending wns -0.9\n");
+
+    const grep = await session.grepOutput("wns");
+
+    expect(grep.totalMatches).toBe(1);
+    expect(grep.matches[0]!.command).toBe("(unread buffer)");
+  });
+
+  it("reports an empty search rather than pretending nothing matched", async () => {
+    const grep = await session.grepOutput("anything");
+
+    expect(grep.totalMatches).toBe(0);
+    expect(grep.searchedCommands).toBe(0);
+    expect(grep.retainedChars).toBe(0);
+  });
+});

--- a/typescript/__tests__/interactive/session.test.ts
+++ b/typescript/__tests__/interactive/session.test.ts
@@ -435,6 +435,26 @@ describe("InteractiveSession", () => {
       expect(session.commandCount).toBe(0);
     });
 
+    it("keeps the startup probe out of the searchable output history", async () => {
+      wirePty({ thinkMs: 10, output: "ORMCP-READY-OK\r\n" });
+      await session.verifyResponsive(2000);
+
+      // The probe ran through runCommand, so its output was being retained and
+      // charged to the retention budget like a user command.
+      const probe = await session.grepOutput("ORMCP-READY-OK");
+      expect(probe.totalMatches).toBe(0);
+      expect(probe.retainedChars).toBe(0);
+
+      // It also consumed command number 1 before verifyResponsive reset the
+      // counter, so the caller's first real command collided with it.
+      wirePty({ thinkMs: 10, output: "wns max -0.485\r\n" });
+      await session.runCommand("report_checks", 2000);
+
+      const grep = await session.grepOutput("wns max");
+      expect(grep.searchedCommands).toBe(1);
+      expect(grep.matches.map((m) => m.commandNumber)).toEqual([1]);
+    });
+
     it("reports a timeout even when the partial output contains an error pattern", async () => {
       wirePty({ thinkMs: 10, output: "Error: something went wrong\r\n", emitSentinel: false });
 

--- a/typescript/__tests__/interactive/session.test.ts
+++ b/typescript/__tests__/interactive/session.test.ts
@@ -305,8 +305,13 @@ describe("InteractiveSession", () => {
      * sentinel. `thinkMs` is the whole point -- it reproduces a command that
      * stays quiet longer than the old 100ms completion window.
      */
-    function wirePty(opts: { thinkMs: number; output: string; emitSentinel?: boolean }): void {
-      const { thinkMs, output, emitSentinel = true } = opts;
+    function wirePty(opts: {
+      thinkMs: number;
+      output: string;
+      emitSentinel?: boolean;
+      chunkSize?: number;
+    }): void {
+      const { thinkMs, output, emitSentinel = true, chunkSize } = opts;
       (mockPty.writeInput as ReturnType<typeof vi.fn>).mockImplementation((data: string) => {
         // A terminal echoes the submitted line back as CRLF.
         void session.outputBuffer.append(data.replace(/\r$/, "\r\n"));
@@ -314,7 +319,16 @@ describe("InteractiveSession", () => {
         if (!match) return;
         const nonce = match[1]!;
         setTimeout(() => {
-          void session.outputBuffer.append(output);
+          if (chunkSize === undefined) {
+            void session.outputBuffer.append(output);
+          } else {
+            // A real PTY delivers a long report in many small reads, not one
+            // giant write; chunking reproduces the eviction pattern that
+            // actually loses output in production.
+            for (let i = 0; i < output.length; i += chunkSize) {
+              void session.outputBuffer.append(output.slice(i, i + chunkSize));
+            }
+          }
           if (emitSentinel) void session.outputBuffer.append(`ORMCP-DONE-${nonce}\r\n`);
         }, thinkMs);
       });
@@ -436,6 +450,70 @@ describe("InteractiveSession", () => {
       const result = await session.runCommand("bogus_cmd", 2000);
 
       expect(result.error).toContain("Invalid command");
+    });
+
+    describe("truncation reporting", () => {
+      // The session under test is built with a 1024-character buffer.
+      const CAP = 1024;
+
+      it("reports a complete result as untruncated and leaves output untouched", async () => {
+        wirePty({ thinkMs: 10, output: "wns max -0.485\r\n" });
+
+        const result = await session.runCommand("report_wns", 2000);
+
+        expect(result.truncated).toBe(false);
+        expect(result.bytesDiscarded).toBe(0);
+        expect(result.output).toContain("wns max -0.485");
+        expect(result.output).not.toContain("TRUNCATED");
+        expect(result.totalBytes).toBeGreaterThan(0);
+      });
+
+      it("reports buffer capacity rather than the always-zero residual", async () => {
+        // The S3 bug: buffer_size reported outputBuffer.size, but a result is
+        // only built after the buffer has been drained, so it was always 0 --
+        // the one field that could have signalled truncation was inert.
+        wirePty({ thinkMs: 10, output: "ok\r\n" });
+
+        const result = await session.runCommand("report_wns", 2000);
+
+        expect(result.bufferSize).toBe(CAP);
+      });
+
+      it("flags a result whose head was discarded and accounts for the loss", async () => {
+        const huge = "x".repeat(5000) + "\r\n";
+        wirePty({ thinkMs: 10, output: huge, chunkSize: 64 });
+
+        const result = await session.runCommand("report_checks", 2000);
+
+        expect(result.truncated).toBe(true);
+        expect(result.bytesDiscarded).toBeGreaterThan(0);
+        expect(result.totalBytes).toBeGreaterThanOrEqual(huge.length);
+        // Everything the command produced is either returned or accounted for
+        // as discarded, and what comes back never exceeds the cap.
+        expect(result.totalBytes - result.bytesDiscarded).toBeLessThanOrEqual(CAP);
+      });
+
+      it("announces the truncation inside output, where a reader cannot miss it", async () => {
+        wirePty({ thinkMs: 10, output: "x".repeat(5000) + "\r\n", chunkSize: 64 });
+
+        const result = await session.runCommand("report_checks", 2000);
+
+        expect(result.output.startsWith("[TRUNCATED:")).toBe(true);
+        expect(result.output).toContain("discarded from the START");
+        expect(result.output).toContain("may begin mid-line");
+      });
+
+      it("does not carry one command's discarded bytes into the next result", async () => {
+        wirePty({ thinkMs: 10, output: "x".repeat(5000) + "\r\n", chunkSize: 64 });
+        const truncatedResult = await session.runCommand("report_checks", 2000);
+        expect(truncatedResult.truncated).toBe(true);
+
+        wirePty({ thinkMs: 10, output: "wns max -0.485\r\n" });
+        const cleanResult = await session.runCommand("report_wns", 2000);
+
+        expect(cleanResult.truncated).toBe(false);
+        expect(cleanResult.bytesDiscarded).toBe(0);
+      });
     });
   });
 

--- a/typescript/__tests__/performance/response_sizes.test.ts
+++ b/typescript/__tests__/performance/response_sizes.test.ts
@@ -103,8 +103,15 @@ describe("Token Efficiency", () => {
       InteractiveSessionListResult.parse({ sessions: [], totalCount: 0, activeCount: 0, error: null }) as unknown as Record<string, unknown>,
     );
     // Token counts (floor(len/4)) measured on first run - update if schema changes.
-    expect(tokenEstimate(minimal)).toBeLessThanOrEqual(45);   // ~37 chars baseline
-    expect(tokenEstimate(emptyList)).toBeLessThanOrEqual(20); // ~57 chars baseline
+    //
+    // Raised from 45 when a command result gained truncated / bytes_discarded /
+    // total_bytes: 148 -> 202 chars, 37 -> 50 tokens. That ~13-token cost is
+    // paid on every result and is deliberate -- the three fields together are
+    // what let a caller prove a result is complete rather than assume it, and
+    // reporting them only on truncation would remove that evidence from the
+    // common path.
+    expect(tokenEstimate(minimal)).toBeLessThanOrEqual(55);   // 202 chars
+    expect(tokenEstimate(emptyList)).toBeLessThanOrEqual(20); // 61 chars
   });
 });
 

--- a/typescript/__tests__/performance/response_sizes.test.ts
+++ b/typescript/__tests__/performance/response_sizes.test.ts
@@ -29,7 +29,10 @@ function minimalExecResult(): InteractiveExecResult {
     timestamp: new Date().toISOString(),
     executionTime: 0.01,
     commandCount: 0,
-    bufferSize: 0,
+    bufferSize: 131072,
+    truncated: false,
+    bytesDiscarded: 0,
+    totalBytes: 4,
     error: null,
   };
 }
@@ -41,7 +44,10 @@ function typicalExecResult(): InteractiveExecResult {
     timestamp: new Date().toISOString(),
     executionTime: 0.123,
     commandCount: 5,
-    bufferSize: 1024,
+    bufferSize: 131072,
+    truncated: false,
+    bytesDiscarded: 0,
+    totalBytes: 69,
     error: null,
   };
 }

--- a/typescript/__tests__/server.test.ts
+++ b/typescript/__tests__/server.test.ts
@@ -18,6 +18,7 @@ const EXPECTED_TOOLS = [
   "get_session_metrics",
   "list_report_images",
   "read_report_image",
+  "read_orfs_metrics",
 ].sort();
 
 /** Minimal manager stub: listing tools needs no calls; one round-trip uses listSessions. */
@@ -37,7 +38,7 @@ async function connectClient(manager: OpenROADManager): Promise<Client> {
 }
 
 describe("createMcpServer over MCP", () => {
-  it("enumerates exactly the 10 expected tools", async () => {
+  it("enumerates exactly the 11 expected tools", async () => {
     const client = await connectClient(makeMockManager());
     const { tools } = await client.listTools();
 

--- a/typescript/__tests__/server.test.ts
+++ b/typescript/__tests__/server.test.ts
@@ -19,6 +19,9 @@ const EXPECTED_TOOLS = [
   "list_report_images",
   "read_report_image",
   "read_orfs_metrics",
+  "run_orfs_stage",
+  "get_orfs_job",
+  "cancel_orfs_job",
 ].sort();
 
 /** Minimal manager stub: listing tools needs no calls; one round-trip uses listSessions. */
@@ -38,7 +41,7 @@ async function connectClient(manager: OpenROADManager): Promise<Client> {
 }
 
 describe("createMcpServer over MCP", () => {
-  it("enumerates exactly the 11 expected tools", async () => {
+  it("enumerates exactly the 14 expected tools", async () => {
     const client = await connectClient(makeMockManager());
     const { tools } = await client.listTools();
 

--- a/typescript/__tests__/server.test.ts
+++ b/typescript/__tests__/server.test.ts
@@ -22,6 +22,7 @@ const EXPECTED_TOOLS = [
   "run_orfs_stage",
   "get_orfs_job",
   "cancel_orfs_job",
+  "grep_session_output",
 ].sort();
 
 /** Minimal manager stub: listing tools needs no calls; one round-trip uses listSessions. */
@@ -41,7 +42,7 @@ async function connectClient(manager: OpenROADManager): Promise<Client> {
 }
 
 describe("createMcpServer over MCP", () => {
-  it("enumerates exactly the 14 expected tools", async () => {
+  it("enumerates exactly the 15 expected tools", async () => {
     const client = await connectClient(makeMockManager());
     const { tools } = await client.listTools();
 

--- a/typescript/__tests__/tools/__snapshots__/interactive.test.ts.snap
+++ b/typescript/__tests__/tools/__snapshots__/interactive.test.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`Snapshots: wire format stability > ListSessionsTool with sessions 1`] = `"{"sessions":[{"session_id":"session-1","created_at":"2024-01-01T00:00:00.000Z","is_alive":true,"command_count":5,"buffer_size":1024,"uptime_seconds":100,"state":"active","error":null}],"total_count":1,"active_count":1,"error":null}"`;
 
-exports[`Snapshots: wire format stability > QueryShellTool success output 1`] = `"{"output":"test output","session_id":"session-1","timestamp":"2024-01-01T00:00:00.000Z","execution_time":0.1,"command_count":1,"buffer_size":0,"error":null}"`;
+exports[`Snapshots: wire format stability > QueryShellTool success output 1`] = `"{"output":"test output","session_id":"session-1","timestamp":"2024-01-01T00:00:00.000Z","execution_time":0.1,"command_count":1,"buffer_size":131072,"truncated":false,"bytes_discarded":0,"total_bytes":11,"error":null}"`;

--- a/typescript/__tests__/tools/flow_run.test.ts
+++ b/typescript/__tests__/tools/flow_run.test.ts
@@ -232,16 +232,20 @@ describe("RunOrfsStageTool", () => {
     const logsDir = path.join(tmpDir, "logs", "nangate45", "gcd", "base");
     fs.mkdirSync(logsDir, { recursive: true });
     fs.writeFileSync(
-      path.join(logsDir, "4_1_cts.json"),
-      `{"cts__utilization__before__dpl": 76.7787,
-        "cts__utilization__before__dpl": 82.1146,
-        "cts__timing__setup__ws": -0.113089}`,
-    );
-    fs.writeFileSync(
       path.join(tmpDir, "designs", "nangate45", "gcd", "rules-base.json"),
       JSON.stringify({ "cts__timing__setup__ws": { value: -0.0529, compare: ">=" } }),
     );
-    const registry = new FlowJobRegistry(stub("quick.sh", "echo ok"));
+    // Written by the run itself, as ORFS would: results are only attributed to
+    // a job when the stage file postdates the job's start.
+    const registry = new FlowJobRegistry(
+      stub(
+        "writes_cts.sh",
+        `cat > ${path.join(logsDir, "4_1_cts.json")} <<'JSON'\n` +
+          `{"cts__utilization__before__dpl": 76.7787,\n` +
+          ` "cts__utilization__before__dpl": 82.1146,\n` +
+          ` "cts__timing__setup__ws": -0.113089}\nJSON`,
+      ),
+    );
 
     const result = JSON.parse(
       await tool(registry).execute("gcd", "cts", null, null, "base", 8),
@@ -256,6 +260,50 @@ describe("RunOrfsStageTool", () => {
 });
 
 describe("GetOrfsJobTool and CancelOrfsJobTool", () => {
+  it("does not report a previous run's metrics as this job's results", async () => {
+    // `make` with an up-to-date target exits in milliseconds having written
+    // nothing. The stage files from the last run are still on disk, and
+    // returning them turns "nothing happened" into a green QoR report.
+    const logsDir = path.join(tmpDir, "logs", "nangate45", "gcd", "base");
+    fs.mkdirSync(logsDir, { recursive: true });
+    const stale = path.join(logsDir, "4_1_cts.json");
+    fs.writeFileSync(stale, `{"cts__timing__setup__ws": -0.1}`);
+    const old = new Date(Date.now() - 3_600_000);
+    fs.utimesSync(stale, old, old);
+    fs.writeFileSync(
+      path.join(tmpDir, "designs", "nangate45", "gcd", "rules-base.json"),
+      JSON.stringify({ "cts__timing__setup__ws": { value: -0.5, compare: ">=" } }),
+    );
+    const registry = new FlowJobRegistry(stub("noop.sh", "echo \"Nothing to be done\""));
+
+    const result = JSON.parse(
+      await new RunOrfsStageTool(stubManager, registry).execute(
+        "gcd", "cts", null, null, "base", 8,
+      ),
+    );
+
+    expect(result.status).toBe("succeeded");
+    expect(result.stages).toEqual([]);
+    expect(result.gates).toEqual([]);
+  });
+
+  it("reports metrics the run did write", async () => {
+    const logsDir = path.join(tmpDir, "logs", "nangate45", "gcd", "base");
+    fs.mkdirSync(logsDir, { recursive: true });
+    const registry = new FlowJobRegistry(
+      stub("writes.sh", `echo '{"cts__timing__setup__ws": -0.1}' > ${path.join(logsDir, "4_1_cts.json")}`),
+    );
+
+    const result = JSON.parse(
+      await new RunOrfsStageTool(stubManager, registry).execute(
+        "gcd", "cts", null, null, "base", 8,
+      ),
+    );
+
+    expect(result.stages).toHaveLength(1);
+    expect(result.stages[0].stage).toBe("4_1_cts");
+  });
+
   it("lists every run when no job_id is given", async () => {
     const registry = new FlowJobRegistry(stub("quick.sh", "echo ok"));
     await new RunOrfsStageTool(stubManager, registry).execute("gcd", "cts", null, null, "base", 8);

--- a/typescript/__tests__/tools/flow_run.test.ts
+++ b/typescript/__tests__/tools/flow_run.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+vi.mock("../../src/config/settings.js", () => ({
+  getSettings: vi.fn(() => ({ LOG_LEVEL: "SILENT" })),
+}));
+
+import { getSettings } from "../../src/config/settings.js";
+import {
+  RunOrfsStageTool,
+  GetOrfsJobTool,
+  CancelOrfsJobTool,
+  validateTarget,
+  validateOverrides,
+  ALLOWED_TARGETS,
+} from "../../src/tools/flow_run.js";
+import { FlowJobRegistry } from "../../src/core/flow_jobs.js";
+import { ValidationError } from "../../src/exceptions.js";
+import type { OpenROADManager } from "../../src/core/manager.js";
+
+const stubManager = {} as unknown as OpenROADManager;
+let tmpDir: string;
+
+function setSettings(over: Record<string, unknown> = {}): void {
+  (getSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+    LOG_LEVEL: "SILENT",
+    RUN_LOG_DIR: path.join(tmpDir, "runs"),
+    MAX_FLOW_JOBS: 2,
+    FLOW_RUN_TIMEOUT: 3600,
+    flowPath: tmpDir,
+    platforms: ["nangate45"],
+    designs: (p: string) => (p === "nangate45" ? ["gcd"] : []),
+    ...over,
+  });
+}
+
+function stub(name: string, body: string): string {
+  const file = path.join(tmpDir, name);
+  fs.writeFileSync(file, `#!/bin/sh\n${body}\n`);
+  fs.chmodSync(file, 0o755);
+  return file;
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "flow-run-test-"));
+  fs.mkdirSync(path.join(tmpDir, "designs", "nangate45", "gcd"), { recursive: true });
+  setSettings();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+describe("validateTarget", () => {
+  it("accepts the ORFS stage and clean targets", () => {
+    for (const t of ["synth", "floorplan", "place", "cts", "grt", "route", "finish", "clean_cts"]) {
+      expect(validateTarget(t)).toBe(t);
+    }
+  });
+
+  it("rejects a target that would become a make flag", () => {
+    // Without an allowlist this reaches make as an argument, not a goal.
+    expect(() => validateTarget("-f/tmp/evil.mk")).toThrow(ValidationError);
+    expect(() => validateTarget("--eval=$(shell id)")).toThrow(ValidationError);
+  });
+
+  it("rejects unknown and path-like targets", () => {
+    expect(() => validateTarget("../../x")).toThrow(ValidationError);
+    expect(() => validateTarget("install")).toThrow(ValidationError);
+    expect(() => validateTarget("")).toThrow(ValidationError);
+  });
+
+  it("names what is allowed so a caller can correct itself", () => {
+    expect(() => validateTarget("nope")).toThrow(/Allowed:.*cts.*route/s);
+  });
+
+  it("does not quietly allow shell-ish targets", () => {
+    expect(ALLOWED_TARGETS.has("cts; id")).toBe(false);
+  });
+});
+
+describe("validateOverrides", () => {
+  it("accepts the knobs the study actually swept", () => {
+    expect(
+      validateOverrides({ PLACE_DENSITY_LB_ADDON: "0.25", CTS_CLUSTER_SIZE: "20" }),
+    ).toEqual({ PLACE_DENSITY_LB_ADDON: "0.25", CTS_CLUSTER_SIZE: "20" });
+  });
+
+  it("accepts a value with spaces, which is one argv entry not a shell string", () => {
+    expect(validateOverrides({ CTS_BUF_LIST: "CLKBUF_X2 CLKBUF_X4" })).toEqual({
+      CTS_BUF_LIST: "CLKBUF_X2 CLKBUF_X4",
+    });
+  });
+
+  it("rejects keys that are not make variable names", () => {
+    expect(() => validateOverrides({ "a;b": "1" })).toThrow(/valid make variable name/);
+    expect(() => validateOverrides({ lowercase: "1" })).toThrow(ValidationError);
+    expect(() => validateOverrides({ "X Y": "1" })).toThrow(ValidationError);
+  });
+
+  it("rejects variables that control how make executes recipes", () => {
+    // shell:false stops a shell reinterpreting a value, but make will happily
+    // use an overridden SHELL to run every recipe.
+    for (const key of ["SHELL", "MAKESHELL", "MAKE", "MAKEFLAGS", "PATH", "LD_PRELOAD"]) {
+      expect(() => validateOverrides({ [key]: "/bin/sh" })).toThrow(/controls how make executes/);
+    }
+  });
+
+  it("rejects values make would expand", () => {
+    expect(() => validateOverrides({ FOO: "$(shell id)" })).toThrow(/expands these/);
+    expect(() => validateOverrides({ FOO: "${HOME}" })).toThrow(ValidationError);
+    expect(() => validateOverrides({ FOO: "`id`" })).toThrow(ValidationError);
+  });
+
+  it("rejects newlines, which would forge extra make arguments", () => {
+    expect(() => validateOverrides({ FOO: "a\nBAR=b" })).toThrow(/newlines/);
+    expect(() => validateOverrides({ FOO: "a\0b" })).toThrow(ValidationError);
+  });
+
+  it("treats no overrides as an empty set", () => {
+    expect(validateOverrides(undefined)).toEqual({});
+    expect(validateOverrides(null)).toEqual({});
+  });
+});
+
+describe("RunOrfsStageTool", () => {
+  function tool(registry: FlowJobRegistry): RunOrfsStageTool {
+    return new RunOrfsStageTool(stubManager, registry);
+  }
+
+  it("runs a stage and returns the finished result inline when asked to wait", async () => {
+    const registry = new FlowJobRegistry(stub("quick.sh", "echo cts done"));
+
+    const result = JSON.parse(
+      await tool(registry).execute("gcd", "cts", null, null, "base", 8),
+    );
+
+    expect(result.error).toBeNull();
+    expect(result.status).toBe("succeeded");
+    expect(result.platform).toBe("nangate45");
+    expect(result.exit_code).toBe(0);
+    expect(result.command).toContain("cts");
+  });
+
+  it("returns a job_id immediately for a long run rather than blocking", async () => {
+    const registry = new FlowJobRegistry(stub("slow.sh", "sleep 300"));
+
+    const result = JSON.parse(await tool(registry).execute("gcd", "route"));
+
+    expect(result.status).toBe("running");
+    expect(result.job_id).toHaveLength(8);
+    await registry.shutdown();
+  });
+
+  it("puts each override on the command line as its own assignment", async () => {
+    const registry = new FlowJobRegistry(stub("quick.sh", "echo ok"));
+
+    const result = JSON.parse(
+      await tool(registry).execute(
+        "gcd", "cts", { CTS_CLUSTER_SIZE: "20" }, null, "base", 8,
+      ),
+    );
+
+    expect(result.command).toContain("CTS_CLUSTER_SIZE=20");
+    expect(result.command).toContain("DESIGN_CONFIG=./designs/nangate45/gcd/config.mk");
+    expect(result.overrides).toEqual({ CTS_CLUSTER_SIZE: "20" });
+  });
+
+  it("passes -n for a dry run", async () => {
+    const registry = new FlowJobRegistry(stub("quick.sh", "echo ok"));
+
+    const result = JSON.parse(
+      await tool(registry).execute("gcd", "route", null, null, "base", 8, null, null, true),
+    );
+
+    expect(result.command).toContain(" -n ");
+    expect(result.dry_run).toBe(true);
+  });
+
+  it("rejects a bad target before spawning anything", async () => {
+    const registry = new FlowJobRegistry(stub("quick.sh", "echo ok"));
+
+    const result = JSON.parse(await tool(registry).execute("gcd", "-f/tmp/evil.mk"));
+
+    expect(result.error).toBe("ValidationError");
+    expect(registry.size).toBe(0);
+  });
+
+  it("rejects a dangerous override before spawning anything", async () => {
+    const registry = new FlowJobRegistry(stub("quick.sh", "echo ok"));
+
+    const result = JSON.parse(
+      await tool(registry).execute("gcd", "cts", { SHELL: "/bin/sh" }),
+    );
+
+    expect(result.error).toBe("ValidationError");
+    expect(registry.size).toBe(0);
+  });
+
+  it("rejects an unknown design", async () => {
+    const registry = new FlowJobRegistry(stub("quick.sh", "echo ok"));
+
+    const result = JSON.parse(await tool(registry).execute("nosuchdesign", "cts"));
+
+    expect(result.error).toBe("ValidationError");
+  });
+
+  it("rejects path traversal in design and variant", async () => {
+    const registry = new FlowJobRegistry(stub("quick.sh", "echo ok"));
+
+    expect(JSON.parse(await tool(registry).execute("..", "cts")).error).toBe("ValidationError");
+    expect(
+      JSON.parse(await tool(registry).execute("gcd", "cts", null, null, "../x")).error,
+    ).toBe("ValidationError");
+  });
+
+  it("reports the concurrency limit rather than piling runs on", async () => {
+    setSettings({ MAX_FLOW_JOBS: 1 });
+    const registry = new FlowJobRegistry(stub("slow.sh", "sleep 300"));
+    await tool(registry).execute("gcd", "route");
+
+    const result = JSON.parse(await tool(registry).execute("gcd", "cts"));
+
+    expect(result.error).toBe("FlowJobLimit");
+    await registry.shutdown();
+  });
+
+  it("attaches stage metrics and gate verdicts once a run succeeds", async () => {
+    const logsDir = path.join(tmpDir, "logs", "nangate45", "gcd", "base");
+    fs.mkdirSync(logsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(logsDir, "4_1_cts.json"),
+      `{"cts__utilization__before__dpl": 76.7787,
+        "cts__utilization__before__dpl": 82.1146,
+        "cts__timing__setup__ws": -0.113089}`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "designs", "nangate45", "gcd", "rules-base.json"),
+      JSON.stringify({ "cts__timing__setup__ws": { value: -0.0529, compare: ">=" } }),
+    );
+    const registry = new FlowJobRegistry(stub("quick.sh", "echo ok"));
+
+    const result = JSON.parse(
+      await tool(registry).execute("gcd", "cts", null, null, "base", 8),
+    );
+
+    expect(result.stages[0].stage).toBe("4_1_cts");
+    // Repeated keys survive as arrays, exactly as read_orfs_metrics returns them.
+    expect(result.stages[0].metrics.cts__utilization__before__dpl).toEqual([76.7787, 82.1146]);
+    expect(result.gates[0]).toMatchObject({ metric: "cts__timing__setup__ws", status: "fail" });
+    expect(result.gate_summary.fail).toBe(1);
+  });
+});
+
+describe("GetOrfsJobTool and CancelOrfsJobTool", () => {
+  it("lists every run when no job_id is given", async () => {
+    const registry = new FlowJobRegistry(stub("quick.sh", "echo ok"));
+    await new RunOrfsStageTool(stubManager, registry).execute("gcd", "cts", null, null, "base", 8);
+
+    const result = JSON.parse(await new GetOrfsJobTool(stubManager, registry).execute());
+
+    expect(result.total_count).toBe(1);
+    expect(result.jobs[0].stage).toBe("cts");
+  });
+
+  it("returns live progress for one run", async () => {
+    const registry = new FlowJobRegistry(stub("quick.sh", "echo ok"));
+    const started = JSON.parse(
+      await new RunOrfsStageTool(stubManager, registry).execute("gcd", "route", null, null, "base", 8),
+    );
+    fs.appendFileSync(
+      started.log_path,
+      "[INFO DRT-0195] Start 1st optimization iteration.\n    Completing 80% with 19604 violations.\n",
+    );
+
+    const result = JSON.parse(
+      await new GetOrfsJobTool(stubManager, registry).execute(started.job_id),
+    );
+
+    expect(result.progress.iteration).toBe(1);
+    expect(result.progress.violations).toBe(19604);
+    expect(result.recent_lines.length).toBeGreaterThan(0);
+  });
+
+  it("reports an unknown job rather than throwing", async () => {
+    const registry = new FlowJobRegistry(stub("quick.sh", "echo ok"));
+
+    const result = JSON.parse(await new GetOrfsJobTool(stubManager, registry).execute("nope"));
+
+    expect(result.error).toBe("FlowJobNotFound");
+  });
+
+  it("cancels a running job", async () => {
+    const registry = new FlowJobRegistry(stub("slow.sh", "sleep 300"));
+    const started = JSON.parse(
+      await new RunOrfsStageTool(stubManager, registry).execute("gcd", "route"),
+    );
+
+    const result = JSON.parse(
+      await new CancelOrfsJobTool(stubManager, registry).execute(started.job_id),
+    );
+
+    expect(result.cancelled).toBe(true);
+    expect(result.status).toBe("cancelled");
+  });
+
+  it("reports an unknown job on cancel", async () => {
+    const registry = new FlowJobRegistry(stub("quick.sh", "echo ok"));
+
+    const result = JSON.parse(await new CancelOrfsJobTool(stubManager, registry).execute("nope"));
+
+    expect(result.error).toBe("FlowJobNotFound");
+  });
+});

--- a/typescript/__tests__/tools/interactive.test.ts
+++ b/typescript/__tests__/tools/interactive.test.ts
@@ -117,6 +117,9 @@ describe("QueryShellTool", () => {
     expect(Object.keys(result)).toContain("execution_time");
     expect(Object.keys(result)).toContain("command_count");
     expect(Object.keys(result)).toContain("buffer_size");
+    expect(Object.keys(result)).toContain("truncated");
+    expect(Object.keys(result)).toContain("bytes_discarded");
+    expect(Object.keys(result)).toContain("total_bytes");
   });
 
   it("handles SessionNotFoundError", async () => {

--- a/typescript/__tests__/tools/interactive.test.ts
+++ b/typescript/__tests__/tools/interactive.test.ts
@@ -139,6 +139,19 @@ describe("QueryShellTool", () => {
     expect(Object.keys(converted)).toContain("session_id");
   });
 
+  it("leaves a single-token override name alone", async () => {
+    // CORNER and JOBS carry no underscore and no colon, so the guards written
+    // for CTS_CLUSTER_SIZE did not reach them: CORNER became _c_o_r_n_e_r,
+    // destroying a name run_orfs_stage documents as returned verbatim.
+    const converted = toSnakeCase({
+      overrides: { CORNER: "fast", JOBS: "8", GDS: "x.gds" },
+      sessionId: "s1",
+    }) as Record<string, Record<string, string>>;
+
+    expect(Object.keys(converted.overrides!)).toEqual(["CORNER", "JOBS", "GDS"]);
+    expect(Object.keys(converted)).toContain("session_id");
+  });
+
   it("leaves an ORFS metric key carrying a mixed-case site name intact", async () => {
     // Observed in a real run: the key is mostly lowercase, so a
     // "has no lowercase letters" guard does not protect it, and the site name

--- a/typescript/__tests__/tools/interactive.test.ts
+++ b/typescript/__tests__/tools/interactive.test.ts
@@ -139,6 +139,19 @@ describe("QueryShellTool", () => {
     expect(Object.keys(converted)).toContain("session_id");
   });
 
+  it("leaves an ORFS metric key carrying a mixed-case site name intact", async () => {
+    // Observed in a real run: the key is mostly lowercase, so a
+    // "has no lowercase letters" guard does not protect it, and the site name
+    // after the colon was rewritten to gibberish.
+    const converted = toSnakeCase({
+      "cts__design__rows:FreePDK45_38x28_10R_NP_162NW_34o": 23,
+    }) as Record<string, unknown>;
+
+    expect(Object.keys(converted)).toEqual([
+      "cts__design__rows:FreePDK45_38x28_10R_NP_162NW_34o",
+    ]);
+  });
+
   it("handles SessionNotFoundError", async () => {
     mgr.executeCommand.mockRejectedValue(new SessionNotFoundError("not found", "session-1"));
     const raw = await tool.execute("help", "session-1");

--- a/typescript/__tests__/tools/interactive.test.ts
+++ b/typescript/__tests__/tools/interactive.test.ts
@@ -15,7 +15,10 @@ function makeExecResult(overrides: Partial<InteractiveExecResult> = {}): Interac
     timestamp: NOW,
     executionTime: 0.1,
     commandCount: 1,
-    bufferSize: 0,
+    bufferSize: 131072,
+    truncated: false,
+    bytesDiscarded: 0,
+    totalBytes: 11,
     error: null,
     ...overrides,
   };

--- a/typescript/__tests__/tools/interactive.test.ts
+++ b/typescript/__tests__/tools/interactive.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { Mock } from "vitest";
-import { QueryShellTool, ExecShellTool, ListSessionsTool, CreateSessionTool, TerminateSessionTool, InspectSessionTool, SessionHistoryTool, SessionMetricsTool, InteractiveShellTool } from "../../src/tools/interactive.js";
+import { GrepSessionOutputTool, QueryShellTool, ExecShellTool, ListSessionsTool, CreateSessionTool, TerminateSessionTool, InspectSessionTool, SessionHistoryTool, SessionMetricsTool, InteractiveShellTool } from "../../src/tools/interactive.js";
 import type { OpenROADManager } from "../../src/core/manager.js";
 import { SessionNotFoundError, SessionTerminatedError, SessionError } from "../../src/interactive/models.js";
 import { SessionState } from "../../src/core/models.js";
@@ -472,5 +472,89 @@ describe("Snapshots: wire format stability", () => {
     mgr.listSessions.mockResolvedValue([makeSessionInfo()]);
     const raw = await new ListSessionsTool(mgr as unknown as OpenROADManager).execute();
     expect(raw).toMatchSnapshot();
+  });
+});
+
+describe("GrepSessionOutputTool", () => {
+  function makeManager(over: Partial<Record<string, unknown>> = {}): OpenROADManager {
+    return {
+      grepSessionOutput: vi.fn().mockResolvedValue({
+        matches: [
+          { commandNumber: 1, command: "report_checks", lineNumber: 42, line: "wns max -0.485" },
+        ],
+        totalMatches: 1,
+        truncated: false,
+        patternKind: "regex",
+        searchedCommands: 1,
+        searchedLines: 900,
+        retainedChars: 131166,
+        evictedCommands: 0,
+      }),
+      ...over,
+    } as unknown as OpenROADManager;
+  }
+
+  it("returns matches with their command and line number in snake_case", async () => {
+    const raw = await new GrepSessionOutputTool(makeManager()).execute("s1", "wns");
+    const result = JSON.parse(raw);
+
+    expect(result.error).toBeNull();
+    expect(result.total_matches).toBe(1);
+    expect(result.matches[0]).toMatchObject({
+      command_number: 1,
+      command: "report_checks",
+      line_number: 42,
+      line: "wns max -0.485",
+    });
+    expect(result.searched_lines).toBe(900);
+  });
+
+  it("forwards the search options it was given", async () => {
+    const mgr = makeManager();
+    await new GrepSessionOutputTool(mgr).execute("s1", "wns", 10, 2, false, 3);
+
+    expect(mgr.grepSessionOutput).toHaveBeenCalledWith("s1", "wns", {
+      maxMatches: 10,
+      contextLines: 2,
+      ignoreCase: false,
+      commandNumber: 3,
+    });
+  });
+
+  it("says plainly when matches were capped", async () => {
+    const mgr = makeManager({
+      grepSessionOutput: vi.fn().mockResolvedValue({
+        matches: [], totalMatches: 500, truncated: true, patternKind: "regex",
+        searchedCommands: 2, searchedLines: 9000, retainedChars: 1000, evictedCommands: 0,
+      }),
+    });
+
+    const result = JSON.parse(await new GrepSessionOutputTool(mgr).execute("s1", "slack"));
+
+    expect(result.truncated).toBe(true);
+    expect(result.message).toMatch(/of 500 matches/);
+  });
+
+  it("explains an empty search rather than looking like a clean miss", async () => {
+    const mgr = makeManager({
+      grepSessionOutput: vi.fn().mockResolvedValue({
+        matches: [], totalMatches: 0, truncated: false, patternKind: "regex",
+        searchedCommands: 0, searchedLines: 0, retainedChars: 0, evictedCommands: 0,
+      }),
+    });
+
+    const result = JSON.parse(await new GrepSessionOutputTool(mgr).execute("s1", "wns"));
+
+    expect(result.message).toMatch(/No command output is retained/);
+  });
+
+  it("reports a missing session as a structured error", async () => {
+    const mgr = makeManager({
+      grepSessionOutput: vi.fn().mockRejectedValue(new SessionNotFoundError("nope", "s9")),
+    });
+
+    const result = JSON.parse(await new GrepSessionOutputTool(mgr).execute("s9", "wns"));
+
+    expect(result.error).toBe("SessionNotFound");
   });
 });

--- a/typescript/__tests__/tools/interactive.test.ts
+++ b/typescript/__tests__/tools/interactive.test.ts
@@ -4,6 +4,7 @@ import { QueryShellTool, ExecShellTool, ListSessionsTool, CreateSessionTool, Ter
 import type { OpenROADManager } from "../../src/core/manager.js";
 import { SessionNotFoundError, SessionTerminatedError, SessionError } from "../../src/interactive/models.js";
 import { SessionState } from "../../src/core/models.js";
+import { toSnakeCase } from "../../src/tools/base.js";
 import type { InteractiveExecResult, InteractiveSessionInfo, SessionDetailedMetrics, ManagerMetrics } from "../../src/core/models.js";
 
 const NOW = "2024-01-01T00:00:00.000Z";
@@ -120,6 +121,22 @@ describe("QueryShellTool", () => {
     expect(Object.keys(result)).toContain("truncated");
     expect(Object.keys(result)).toContain("bytes_discarded");
     expect(Object.keys(result)).toContain("total_bytes");
+  });
+
+  it("leaves SCREAMING_SNAKE data keys alone rather than mangling them", async () => {
+    // An ORFS make variable arrives as data, not as a camelCase field name.
+    // Converting it yields _c_t_s__c_l_u_s_t_e_r__s_i_z_e and destroys a name
+    // the caller has to be able to read back.
+    const converted = toSnakeCase({
+      overrides: { CTS_CLUSTER_SIZE: "20", PLACE_DENSITY_LB_ADDON: "0.25" },
+      sessionId: "s1",
+    }) as Record<string, Record<string, string>>;
+
+    expect(Object.keys(converted.overrides!)).toEqual([
+      "CTS_CLUSTER_SIZE",
+      "PLACE_DENSITY_LB_ADDON",
+    ]);
+    expect(Object.keys(converted)).toContain("session_id");
   });
 
   it("handles SessionNotFoundError", async () => {

--- a/typescript/__tests__/tools/interactive.test.ts
+++ b/typescript/__tests__/tools/interactive.test.ts
@@ -229,6 +229,19 @@ describe("ExecShellTool", () => {
     const result = JSON.parse(raw);
     expect(result.output).toContain("not found");
   });
+
+  it("tells the caller how to render a timing path when gui::show is blocked", async () => {
+    // "not on the allowlist" alone is a dead end here: the caller wants an
+    // image and there is a form that produces one headlessly.
+    const raw = await tool.execute("gui::show");
+    const result = JSON.parse(raw);
+
+    expect(result.error).toMatch(/CommandBlocked/);
+    expect(result.message).toContain("gui::show {<tcl>} false");
+    expect(result.message).toContain("QT_QPA_PLATFORM=offscreen");
+    expect(result.message).toContain("gui::show_worst_path");
+    expect(mgr.executeCommand).not.toHaveBeenCalled();
+  });
 });
 
 describe("ListSessionsTool", () => {

--- a/typescript/__tests__/tools/orfs_metrics.test.ts
+++ b/typescript/__tests__/tools/orfs_metrics.test.ts
@@ -1,0 +1,469 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Mock getSettings so tests do not depend on a filesystem ORFS install.
+vi.mock("../../src/config/settings.js", () => {
+  let mockFlowPath = "/mock/flow";
+  let mockPlatforms: string[] = [];
+  let mockDesigns: Record<string, string[]> = {};
+  return {
+    getSettings: vi.fn(() => ({
+      get flowPath() { return mockFlowPath; },
+      get platforms() { return mockPlatforms; },
+      designs(platform: string) { return mockDesigns[platform] ?? []; },
+    })),
+    __setMock: (fp: string, p: string[], d: Record<string, string[]>) => {
+      mockFlowPath = fp; mockPlatforms = p; mockDesigns = d;
+    },
+  };
+});
+
+import { getSettings } from "../../src/config/settings.js";
+import {
+  ReadOrfsMetricsTool,
+  parseMetricsPreservingDuplicates,
+  resolvePlatform,
+  resolveStages,
+  evaluateGates,
+  compareGate,
+} from "../../src/tools/orfs_metrics.js";
+import type { OpenROADManager } from "../../src/core/manager.js";
+
+const stubManager = {} as unknown as OpenROADManager;
+let tmpDir: string;
+
+/** The stage stems a real nangate45/gcd/base run produces. */
+const REAL_STEMS = [
+  "1_synth", "2_1_floorplan", "2_2_floorplan_macro", "2_3_floorplan_tapcell",
+  "2_4_floorplan_pdn", "3_1_place_gp_skip_io", "3_2_place_iop", "3_3_place_gp",
+  "3_4_place_resized", "3_5_place_dp", "4_1_cts", "5_1_grt", "5_2_route",
+  "5_3_fillcell", "6_1_fill", "6_report",
+];
+
+function mockSettings(flowPath: string, designs: Record<string, string[]>): void {
+  (getSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+    flowPath,
+    platforms: Object.keys(designs),
+    designs: (p: string) => designs[p] ?? [],
+  });
+}
+
+/** Builds a flow tree with logs/, designs/ and the given stage files. */
+function createFlow(opts: {
+  platform?: string;
+  design?: string;
+  variant?: string;
+  stems?: string[];
+  metrics?: Record<string, string>;
+  logs?: Record<string, string>;
+  rules?: Record<string, unknown> | null;
+} = {}) {
+  const platform = opts.platform ?? "nangate45";
+  const design = opts.design ?? "gcd";
+  const variant = opts.variant ?? "base";
+  const flowPath = tmpDir;
+  const logsDir = path.join(flowPath, "logs", platform, design, variant);
+  const designDir = path.join(flowPath, "designs", platform, design);
+  fs.mkdirSync(logsDir, { recursive: true });
+  fs.mkdirSync(designDir, { recursive: true });
+  fs.mkdirSync(path.join(flowPath, "platforms", platform), { recursive: true });
+
+  for (const stem of opts.stems ?? REAL_STEMS) {
+    fs.writeFileSync(path.join(logsDir, `${stem}.json`), opts.metrics?.[stem] ?? "{}");
+    fs.writeFileSync(path.join(logsDir, `${stem}.log`), opts.logs?.[stem] ?? "");
+  }
+  for (const [stem, body] of Object.entries(opts.logs ?? {})) {
+    fs.writeFileSync(path.join(logsDir, `${stem}.log`), body);
+  }
+  if (opts.rules !== null) {
+    fs.writeFileSync(
+      path.join(designDir, "rules-base.json"),
+      JSON.stringify(opts.rules ?? {}),
+    );
+  }
+  mockSettings(flowPath, { [platform]: [design] });
+  return { flowPath, logsDir, designDir };
+}
+
+async function read(tool: ReadOrfsMetricsTool, ...args: Parameters<ReadOrfsMetricsTool["execute"]>) {
+  return JSON.parse(await tool.execute(...args));
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "orfs-metrics-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+describe("parseMetricsPreservingDuplicates", () => {
+  // Verbatim shape of the real flow/logs/nangate45/gcd/base/4_1_cts.json,
+  // which records a block of metrics per sub-run.
+  const REAL_CTS = `{
+\t"cts__utilization__before__dpl": 76.7787,
+\t"cts__design__instance__displacement__max": 6.36,
+\t"cts__route__wirelength__estimated": 3732.03,
+\t"cts__utilization__before__dpl": 82.1146,
+\t"cts__design__instance__displacement__max": 11.77,
+\t"cts__route__wirelength__estimated": 4167.95,
+\t"cts__design__violations": 0,
+\t"cts__timing__setup__ws": -0.113089,
+\t"cts__timing__fmax__clock:core_clock": 2.43841e+09
+}`;
+
+  it("returns every value of a repeated key, in file order", () => {
+    // JSON.parse keeps only 82.1146 and says nothing about the first pass.
+    expect(JSON.parse(REAL_CTS)["cts__utilization__before__dpl"]).toBe(82.1146);
+
+    const { metrics } = parseMetricsPreservingDuplicates(REAL_CTS);
+    expect(metrics["cts__utilization__before__dpl"]).toEqual([76.7787, 82.1146]);
+    expect(metrics["cts__design__instance__displacement__max"]).toEqual([6.36, 11.77]);
+  });
+
+  it("names the repeated keys so a caller need not type-sniff every value", () => {
+    const { repeatedMetrics } = parseMetricsPreservingDuplicates(REAL_CTS);
+    expect(repeatedMetrics.sort()).toEqual([
+      "cts__design__instance__displacement__max",
+      "cts__route__wirelength__estimated",
+      "cts__utilization__before__dpl",
+    ]);
+  });
+
+  it("leaves a key that appears once as a scalar", () => {
+    const { metrics } = parseMetricsPreservingDuplicates(REAL_CTS);
+    expect(metrics["cts__design__violations"]).toBe(0);
+    expect(metrics["cts__timing__setup__ws"]).toBe(-0.113089);
+    expect(metrics["cts__timing__fmax__clock:core_clock"]).toBe(2.43841e9);
+  });
+
+  it("is depth-aware, so braces and quotes inside values cannot desynchronise it", () => {
+    const tricky = `{
+      "nested": {"a": [1, 2, {"b": "}"}], "c": "x\\"y,z"},
+      "after": 42,
+      "arr": [1, {"k": "]"}],
+      "nul": null,
+      "yes": true,
+      "text": "has, comma and : colon"
+    }`;
+    const { metrics } = parseMetricsPreservingDuplicates(tricky);
+    expect(metrics["nested"]).toEqual({ a: [1, 2, { b: "}" }], c: 'x"y,z' });
+    expect(metrics["after"]).toBe(42);
+    expect(metrics["arr"]).toEqual([1, { k: "]" }]);
+    expect(metrics["nul"]).toBeNull();
+    expect(metrics["yes"]).toBe(true);
+    expect(metrics["text"]).toBe("has, comma and : colon");
+  });
+
+  it("rejects a malformed or non-object file with a clean error", () => {
+    expect(() => parseMetricsPreservingDuplicates("{ broken")).toThrow();
+    expect(() => parseMetricsPreservingDuplicates("[1,2]")).toThrow(/top level/);
+  });
+});
+
+describe("resolveStages", () => {
+  it("matches an exact file stem", () => {
+    expect(resolveStages(REAL_STEMS, "4_1_cts")).toEqual(["4_1_cts"]);
+  });
+
+  it("maps everyday stage names onto their numeric group", () => {
+    expect(resolveStages(REAL_STEMS, "cts")).toEqual(["4_1_cts"]);
+    expect(resolveStages(REAL_STEMS, "place")).toEqual([
+      "3_1_place_gp_skip_io", "3_2_place_iop", "3_3_place_gp",
+      "3_4_place_resized", "3_5_place_dp",
+    ]);
+    expect(resolveStages(REAL_STEMS, "floorplan")).toHaveLength(4);
+    expect(resolveStages(REAL_STEMS, "synth")).toEqual(["1_synth"]);
+  });
+
+  it("maps an ORFS metric namespace onto the file that holds it", () => {
+    // A caller reading rules-base.json sees globalroute__*, but the file on
+    // disk is 5_1_grt.json -- unguessable without this mapping.
+    expect(resolveStages(REAL_STEMS, "globalroute")).toEqual(["5_1_grt"]);
+    expect(resolveStages(REAL_STEMS, "detailedroute")).toEqual(["5_2_route"]);
+    expect(resolveStages(REAL_STEMS, "placeopt")).toEqual(["3_4_place_resized"]);
+    expect(resolveStages(REAL_STEMS, "detailedplace")).toEqual(["3_5_place_dp"]);
+    expect(resolveStages(REAL_STEMS, "finish")).toEqual(["6_report"]);
+  });
+
+  it("returns everything for 'all' and for an empty stage", () => {
+    expect(resolveStages(REAL_STEMS, "all")).toHaveLength(REAL_STEMS.length);
+    expect(resolveStages(REAL_STEMS, "")).toHaveLength(REAL_STEMS.length);
+  });
+
+  it("returns nothing for an unknown stage", () => {
+    expect(resolveStages(REAL_STEMS, "nonsense")).toEqual([]);
+  });
+
+  it("does not depend on a hardcoded stem table", () => {
+    // A renumbered ORFS release must still resolve.
+    const renumbered = ["01_synth", "07_cts", "09_grt"];
+    expect(resolveStages(renumbered, "cts")).toEqual(["07_cts"]);
+    expect(resolveStages(renumbered, "globalroute")).toEqual(["09_grt"]);
+  });
+});
+
+describe("compareGate and evaluateGates", () => {
+  it("applies each comparison operator, including string equality", () => {
+    expect(compareGate(0, "<=", 0)).toBe(true);
+    expect(compareGate(1, "<=", 0)).toBe(false);
+    expect(compareGate(-0.11, ">=", -0.05)).toBe(false);
+    expect(compareGate(-0.01, ">=", -0.05)).toBe(true);
+    expect(compareGate("061b4cd4", "==", "061b4cd4")).toBe(true);
+    expect(compareGate("aaa", "==", "bbb")).toBe(false);
+  });
+
+  it("returns null when a numeric comparison gets a non-number", () => {
+    expect(compareGate("x", ">=", 1)).toBeNull();
+    expect(compareGate(1, "??", 1)).toBeNull();
+  });
+
+  it("defaults a rule with no level to error, as ORFS does", () => {
+    const { gates } = evaluateGates(
+      [{ stage: "4_1_cts", metrics: { "cts__design__violations": 0 } }],
+      { "cts__design__violations": { value: 0, compare: "==" } },
+    );
+    expect(gates[0]!.level).toBe("error");
+    expect(gates[0]!.status).toBe("pass");
+  });
+
+  it("honours an explicit level", () => {
+    const { gates } = evaluateGates(
+      [{ stage: "1_synth", metrics: { "synth__netlist__hash": "abc" } }],
+      { "synth__netlist__hash": { value: "def", compare: "==", level: "warning" } },
+    );
+    expect(gates[0]).toMatchObject({ level: "warning", status: "fail" });
+  });
+
+  it("judges a repeated metric on its last value and flags it as ambiguous", () => {
+    const { gates } = evaluateGates(
+      [{ stage: "4_1_cts", metrics: { "cts__utilization__before__dpl": [76.7787, 82.1146] } }],
+      { "cts__utilization__before__dpl": { value: 80, compare: "<=" } },
+    );
+    expect(gates[0]!.value).toBe(82.1146);
+    expect(gates[0]!.status).toBe("fail");
+    expect(gates[0]!.ambiguous).toBe(true);
+  });
+
+  it("reports a rule whose metric never appeared rather than dropping it", () => {
+    const { gates, unmatched } = evaluateGates(
+      [{ stage: "4_1_cts", metrics: { "cts__design__violations": 0 } }],
+      {
+        "cts__design__violations": { value: 0, compare: "==" },
+        "finish__timing__setup__ws": { value: -0.05, compare: ">=" },
+      },
+    );
+    expect(gates).toHaveLength(1);
+    expect(unmatched).toEqual([
+      { metric: "finish__timing__setup__ws", threshold: -0.05, compare: ">=", level: "error" },
+    ]);
+  });
+
+  it("records which stage a gate was judged against", () => {
+    const { gates } = evaluateGates(
+      [
+        { stage: "4_1_cts", metrics: { "cts__timing__setup__ws": -0.1 } },
+        { stage: "6_report", metrics: { "finish__timing__setup__ws": -0.01 } },
+      ],
+      { "finish__timing__setup__ws": { value: -0.05, compare: ">=" } },
+    );
+    expect(gates[0]!.stage).toBe("6_report");
+  });
+});
+
+describe("resolvePlatform", () => {
+  it("infers the platform when the design is unique", () => {
+    createFlow();
+    mockSettings(tmpDir, { nangate45: ["gcd"], sky130hd: ["ibex"] });
+    expect(resolvePlatform("gcd")).toBe("nangate45");
+    expect(resolvePlatform("ibex")).toBe("sky130hd");
+  });
+
+  it("names the candidates when a design exists under several platforms", () => {
+    mockSettings(tmpDir, { nangate45: ["gcd"], sky130hd: ["gcd"] });
+    expect(() => resolvePlatform("gcd")).toThrow(/multiple platforms.*nangate45.*sky130hd/s);
+  });
+
+  it("lists what is available when the design is unknown", () => {
+    mockSettings(tmpDir, { nangate45: ["gcd"] });
+    expect(() => resolvePlatform("nope")).toThrow(/nangate45\/gcd/);
+  });
+
+  it("still validates an explicitly passed platform", () => {
+    mockSettings(tmpDir, { nangate45: ["gcd"] });
+    expect(() => resolvePlatform("gcd", "sky130hd")).toThrow(/Platform 'sky130hd' not found/);
+    expect(() => resolvePlatform("ibex", "nangate45")).toThrow(/Design 'ibex' not found/);
+  });
+});
+
+describe("ReadOrfsMetricsTool", () => {
+  const tool = () => new ReadOrfsMetricsTool(stubManager);
+
+  it("returns one stage's metrics, arrays intact, from a design name alone", async () => {
+    createFlow({
+      metrics: {
+        "4_1_cts": `{"cts__utilization__before__dpl": 76.7787,
+                     "cts__utilization__before__dpl": 82.1146,
+                     "cts__timing__setup__ws": -0.113089}`,
+      },
+    });
+
+    const result = await read(tool(), "gcd", "cts");
+
+    expect(result.error).toBeNull();
+    expect(result.platform).toBe("nangate45");
+    expect(result.variant).toBe("base");
+    expect(result.stages).toHaveLength(1);
+    expect(result.stages[0].stage).toBe("4_1_cts");
+    expect(result.stages[0].metrics.cts__utilization__before__dpl).toEqual([76.7787, 82.1146]);
+    expect(result.stages[0].repeated_metrics).toEqual(["cts__utilization__before__dpl"]);
+  });
+
+  it("evaluates rules-base gates against the metrics it read", async () => {
+    createFlow({
+      metrics: {
+        "4_1_cts": `{"cts__timing__setup__ws": -0.113089, "cts__design__violations": 0}`,
+      },
+      rules: {
+        "cts__timing__setup__ws": { value: -0.0529, compare: ">=" },
+        "cts__design__violations": { value: 0, compare: "==" },
+        "finish__timing__setup__ws": { value: -0.05, compare: ">=" },
+      },
+    });
+
+    const result = await read(tool(), "gcd", "cts");
+
+    const byMetric = Object.fromEntries(result.gates.map((g: { metric: string }) => [g.metric, g]));
+    expect(byMetric["cts__timing__setup__ws"]).toMatchObject({
+      value: -0.113089, threshold: -0.0529, compare: ">=", level: "error", status: "fail",
+    });
+    expect(byMetric["cts__design__violations"].status).toBe("pass");
+    expect(result.unmatched_gates).toHaveLength(1);
+    expect(result.gate_summary).toMatchObject({ pass: 1, fail: 1, failing_errors: 1, unmatched: 1 });
+  });
+
+  it("covers every gate when reading all stages", async () => {
+    createFlow({
+      metrics: {
+        "4_1_cts": `{"cts__timing__setup__ws": -0.11}`,
+        "6_report": `{"finish__timing__setup__ws": -0.01}`,
+      },
+      rules: {
+        "cts__timing__setup__ws": { value: -0.05, compare: ">=" },
+        "finish__timing__setup__ws": { value: -0.05, compare: ">=" },
+      },
+    });
+
+    const result = await read(tool(), "gcd");
+
+    expect(result.stage).toBe("all");
+    expect(result.unmatched_gates).toHaveLength(0);
+    expect(result.gate_summary).toMatchObject({ total: 2, pass: 1, fail: 1 });
+  });
+
+  it("extracts ORFS's tagged diagnostics from the stage log", async () => {
+    createFlow({
+      logs: {
+        "6_report": [
+          "[INFO ORD-0030] Something routine.",
+          "[ERROR ORD-2018] Pin is not ITerm or BTerm or modITerm.",
+          "[WARNING STA-0123] Some warning.",
+          "[ERROR GUI-0070] ORD-2018",
+          "this line mentions error but is not tagged",
+        ].join("\n"),
+      },
+    });
+
+    const result = await read(tool(), "gcd", "finish");
+
+    const log = result.stages[0].log;
+    expect(log.errors).toEqual([
+      "[ERROR ORD-2018] Pin is not ITerm or BTerm or modITerm.",
+      "[ERROR GUI-0070] ORD-2018",
+    ]);
+    expect(log.warnings).toEqual(["[WARNING STA-0123] Some warning."]);
+    expect(log.error_count).toBe(2);
+    expect(log.truncated).toBe(false);
+  });
+
+  it("caps log diagnostics and says so rather than truncating silently", async () => {
+    const noisy = Array.from({ length: 120 }, (_, i) => `[WARNING STA-${i}] noisy`).join("\n");
+    createFlow({ logs: { "6_report": noisy } });
+
+    const log = (await read(tool(), "gcd", "finish")).stages[0].log;
+
+    expect(log.warnings).toHaveLength(50);
+    expect(log.warning_count).toBe(120);
+    expect(log.truncated).toBe(true);
+  });
+
+  it("still reports a stage that has a log but no metrics file", async () => {
+    // A crashed stage often writes no JSON at all; its log is the whole story.
+    const { logsDir } = createFlow({ stems: ["1_synth"] });
+    fs.writeFileSync(path.join(logsDir, "1_2_yosys.log"), "[ERROR YOSYS-1] boom");
+
+    const result = await read(tool(), "gcd", "1_2_yosys");
+
+    expect(result.stages[0].metrics_path).toBeNull();
+    expect(result.stages[0].log.errors).toEqual(["[ERROR YOSYS-1] boom"]);
+  });
+
+  it("flags a half-written metrics file instead of dropping the stage", async () => {
+    createFlow({ stems: ["4_1_cts"], metrics: { "4_1_cts": '{"cts__a": 1,' } });
+
+    const result = await read(tool(), "gcd", "cts");
+
+    expect(result.error).toBeNull();
+    expect(result.stages[0].error).toMatch(/MalformedMetrics/);
+  });
+
+  it("lists the stages that exist when the requested one does not", async () => {
+    createFlow({ stems: ["4_1_cts", "6_report"] });
+
+    const result = await read(tool(), "gcd", "nonsense");
+
+    expect(result.error).toBe("StageNotFound");
+    expect(result.message).toContain("4_1_cts");
+    expect(result.message).toContain("6_report");
+  });
+
+  it("reports the available variants when the run does not exist", async () => {
+    createFlow({ variant: "base", stems: ["4_1_cts"] });
+
+    const result = await read(tool(), "gcd", "cts", null, "nosuchvariant");
+
+    expect(result.error).toBe("RunNotFound");
+    expect(result.message).toContain("base");
+  });
+
+  it("says so when the design has no rules-base.json", async () => {
+    createFlow({ stems: ["4_1_cts"], rules: null });
+
+    const result = await read(tool(), "gcd", "cts");
+
+    expect(result.gates).toEqual([]);
+    expect(result.message).toMatch(/No rules-base\.json/);
+  });
+
+  it("rejects path traversal in design and variant", async () => {
+    createFlow({ stems: ["4_1_cts"] });
+
+    for (const bad of ["..", "../../etc", "a/b"]) {
+      expect((await read(tool(), bad, "cts")).error).toBe("ValidationError");
+      expect((await read(tool(), "gcd", "cts", null, bad)).error).toBe("ValidationError");
+    }
+  });
+
+  it("returns paths relative to the flow root, not absolute host paths", async () => {
+    createFlow({ stems: ["4_1_cts"] });
+
+    const result = await read(tool(), "gcd", "cts");
+
+    expect(result.logs_path).toBe("logs/nangate45/gcd/base");
+    expect(result.stages[0].metrics_path).toBe("logs/nangate45/gcd/base/4_1_cts.json");
+    expect(result.rules_path).toBe("designs/nangate45/gcd/rules-base.json");
+  });
+});

--- a/typescript/__tests__/tools/report_images.test.ts
+++ b/typescript/__tests__/tools/report_images.test.ts
@@ -879,6 +879,30 @@ describe("ReadReportImageTool — image content blocks and size budget", () => {
     expect(result.metadata.height).toBe(1099);
   });
 
+  it("sheds quality before resolution when the budget is tight", async () => {
+    // The ladder used to exhaust every size at q85 before dropping to q70, so
+    // a 1099px render that missed the budget at q85 came back as an 824px
+    // thumbnail even though the full-size q70 encoding fit inside it. For a
+    // congestion map that trade is backwards.
+    const { flowPath, runPath } = createFixture("nangate45", "gcd", "run-123", []);
+    await writeNoisyWebp(path.join(runPath, "final_congestion.webp"), 1099, 1099);
+    mockSettings(flowPath);
+
+    const result = JSON.parse(
+      await new ReadReportImageTool(stubManager).execute(
+        "nangate45",
+        "gcd",
+        "run-123",
+        "final_congestion.webp",
+        800,
+      ),
+    );
+
+    expect(result.error).toBeNull();
+    expect(result.metadata.width).toBe(1099);
+    expect(result.metadata.height).toBe(1099);
+  });
+
   it("caps the long edge at the configured maximum and preserves aspect ratio", async () => {
     const { flowPath, runPath } = createFixture("nangate45", "gcd", "run-123", []);
     await writeRealWebp(path.join(runPath, "final_all.webp"), 4000, 2000);

--- a/typescript/__tests__/tools/report_images.test.ts
+++ b/typescript/__tests__/tools/report_images.test.ts
@@ -77,6 +77,20 @@ async function writeRealWebp(filePath: string, width: number, height: number): P
   fs.writeFileSync(filePath, buffer);
 }
 
+/**
+ * Writes a noisy .webp, whose encoded size actually tracks its resolution.
+ * A flat-colour image compresses to a few KB at any size, so it cannot
+ * exercise the size-budget ladder.
+ */
+async function writeNoisyWebp(filePath: string, width: number, height: number): Promise<void> {
+  const pixels = Buffer.allocUnsafe(width * height * 3);
+  for (let i = 0; i < pixels.length; i += 1) pixels[i] = (i * 2654435761) % 256;
+  const buffer = await sharp(pixels, { raw: { width, height, channels: 3 } })
+    .webp({ quality: 100 })
+    .toBuffer();
+  fs.writeFileSync(filePath, buffer);
+}
+
 /** Writes a real PNG, for the `.webp.png` files some ORFS builds emit. */
 async function writeRealPng(filePath: string, width: number, height: number): Promise<void> {
   const buffer = await sharp({
@@ -730,7 +744,9 @@ describe("ReadReportImageTool — additional branch coverage", () => {
       return real;
     });
     try {
-      const raw = await new ReadReportImageTool(stubManager).execute("nangate45", "gcd", "run-123", "final_all.webp");
+      // An explicit 15 KB budget forces the resize ladder; the default budget
+      // is large enough that a report image of this size passes through whole.
+      const raw = await new ReadReportImageTool(stubManager).execute("nangate45", "gcd", "run-123", "final_all.webp", 15);
       const result = JSON.parse(raw);
       expect(result.error).toBeNull();
       expect(result.metadata.compression_applied).toBe(true);
@@ -768,5 +784,160 @@ describe("ReadReportImageTool — additional branch coverage", () => {
     } finally {
       statSpy.mockRestore();
     }
+  });
+});
+
+describe("ReadReportImageTool — image content blocks and size budget", () => {
+  /** Mirrors the settings mock the other read tests install. */
+  function mockSettings(flowPath: string): void {
+    (getSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+      platforms: ["nangate45"],
+      designs: (p: string) => (p === "nangate45" ? ["gcd"] : []),
+      flowPath,
+      WHITELIST_ENABLED: false,
+    });
+  }
+
+  it("returns a real image content block instead of base64 buried in text", async () => {
+    // The S7 failure: read_report_image handed back a single text block of
+    // 33,412 characters of JSON-wrapped base64. A vision model cannot see
+    // that, and the agent that got it tried to decode it by hand and failed.
+    const { flowPath, runPath } = createFixture("nangate45", "gcd", "run-123", []);
+    await writeRealWebp(path.join(runPath, "final_congestion.webp"), 1099, 1099);
+    mockSettings(flowPath);
+
+    const { blocks, isError } = await new ReadReportImageTool(stubManager).executeContent(
+      "nangate45",
+      "gcd",
+      "run-123",
+      "final_congestion.webp",
+    );
+
+    expect(isError).toBe(false);
+    const image = blocks.find((b) => b.type === "image");
+    expect(image).toBeDefined();
+    expect(image).toMatchObject({ type: "image", mimeType: "image/webp" });
+    // The bytes must be real and decodable, not a description of bytes.
+    const decoded = Buffer.from((image as { data: string }).data, "base64");
+    expect((await sharp(decoded).metadata()).width).toBeGreaterThan(0);
+  });
+
+  it("does not repeat the payload in the accompanying text block", async () => {
+    const { flowPath, runPath } = createFixture("nangate45", "gcd", "run-123", []);
+    await writeRealWebp(path.join(runPath, "final_congestion.webp"), 800, 600);
+    mockSettings(flowPath);
+
+    const { blocks } = await new ReadReportImageTool(stubManager).executeContent(
+      "nangate45",
+      "gcd",
+      "run-123",
+      "final_congestion.webp",
+    );
+
+    const textBlock = blocks.find((b) => b.type === "text") as { text: string };
+    const meta = JSON.parse(textBlock.text);
+    expect(meta.image_data).toBeUndefined();
+    expect(meta.metadata.width).toBe(800);
+    expect(meta.metadata.height).toBe(600);
+  });
+
+  it("returns a lone text block and flags isError when the image is missing", async () => {
+    const { flowPath } = createFixture("nangate45", "gcd", "run-123", []);
+    mockSettings(flowPath);
+
+    const { blocks, isError } = await new ReadReportImageTool(stubManager).executeContent(
+      "nangate45",
+      "gcd",
+      "run-123",
+      "nope.webp",
+    );
+
+    expect(isError).toBe(true);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.type).toBe("text");
+    expect(JSON.parse((blocks[0] as { text: string }).text).error).toBe("ImageNotFound");
+  });
+
+  it("keeps a heatmap at full resolution instead of collapsing it to 256x256", async () => {
+    // The old one-shot scale guess drove a 1099x1099 render to the 256x256
+    // floor -- a 35x reduction that makes a congestion map unreadable.
+    const { flowPath, runPath } = createFixture("nangate45", "gcd", "run-123", []);
+    await writeRealWebp(path.join(runPath, "final_ir_drop.webp"), 1099, 1099);
+    mockSettings(flowPath);
+
+    const result = JSON.parse(
+      await new ReadReportImageTool(stubManager).execute(
+        "nangate45",
+        "gcd",
+        "run-123",
+        "final_ir_drop.webp",
+      ),
+    );
+
+    expect(result.error).toBeNull();
+    expect(result.metadata.width).toBe(1099);
+    expect(result.metadata.height).toBe(1099);
+  });
+
+  it("caps the long edge at the configured maximum and preserves aspect ratio", async () => {
+    const { flowPath, runPath } = createFixture("nangate45", "gcd", "run-123", []);
+    await writeRealWebp(path.join(runPath, "final_all.webp"), 4000, 2000);
+    mockSettings(flowPath);
+
+    const result = JSON.parse(
+      await new ReadReportImageTool(stubManager).execute(
+        "nangate45",
+        "gcd",
+        "run-123",
+        "final_all.webp",
+        // A tight budget forces the ladder; aspect ratio must still hold.
+        32,
+      ),
+    );
+
+    expect(result.error).toBeNull();
+    expect(result.metadata.width).toBeGreaterThan(result.metadata.height);
+    expect(result.metadata.width / result.metadata.height).toBeCloseTo(2, 1);
+    expect(result.metadata.original_width).toBe(4000);
+  });
+
+  it("honours a per-call size budget", async () => {
+    const { flowPath, runPath } = createFixture("nangate45", "gcd", "run-123", []);
+    await writeNoisyWebp(path.join(runPath, "final_all.webp"), 1200, 1200);
+    mockSettings(flowPath);
+    const tool = new ReadReportImageTool(stubManager);
+
+    const generous = JSON.parse(
+      await tool.execute("nangate45", "gcd", "run-123", "final_all.webp", 2048),
+    );
+    const stingy = JSON.parse(
+      await tool.execute("nangate45", "gcd", "run-123", "final_all.webp", 16),
+    );
+
+    expect(stingy.metadata.size_bytes).toBeLessThan(generous.metadata.size_bytes);
+    expect(stingy.metadata.width).toBeLessThan(generous.metadata.width);
+    // A tight budget still must not go below the configured floor.
+    expect(stingy.metadata.width).toBeGreaterThanOrEqual(512);
+  });
+
+  it("falls back to documented defaults when settings omit the image knobs", async () => {
+    // Every settings stub in this file predates these fields; a missing knob
+    // must not reach sharp as NaN and silently degrade to raw bytes.
+    const { flowPath, runPath } = createFixture("nangate45", "gcd", "run-123", []);
+    await writeRealWebp(path.join(runPath, "final_all.webp"), 3000, 3000);
+    mockSettings(flowPath);
+
+    const result = JSON.parse(
+      await new ReadReportImageTool(stubManager).execute(
+        "nangate45",
+        "gcd",
+        "run-123",
+        "final_all.webp",
+      ),
+    );
+
+    expect(result.error).toBeNull();
+    expect(result.metadata.width).toBeGreaterThanOrEqual(512);
+    expect(result.metadata.width).toBeLessThanOrEqual(1568);
   });
 });

--- a/typescript/src/config/command_whitelist.ts
+++ b/typescript/src/config/command_whitelist.ts
@@ -327,6 +327,48 @@ function* iterVerbs(command: string): Generator<string> {
 }
 
 /**
+ * Extra guidance for a blocked verb, appended to the generic message. A verb
+ * that is blocked because the *shape* of the call is wrong needs to say what
+ * the right shape is, or the caller has no way to get the job done.
+ */
+export const BLOCK_GUIDANCE: Readonly<Record<string, string>> = {
+  "gui::show":
+    "'gui::show' with no script argument opens the GUI and blocks the Tcl event loop " +
+    "waiting on a human, which wedges the session: the process stays alive but every " +
+    "later command times out. Pass a script and an explicit non-interactive flag " +
+    "instead -- gui::show {<tcl>} false -- which boots the GUI, runs the script and " +
+    "returns. That form works headlessly (set QT_QPA_PLATFORM=offscreen) and is how " +
+    "ORFS renders its report images. To capture a timing path: " +
+    "gui::show {gui::set_display_controls \"Timing Path/*\" visible true; " +
+    "gui::show_worst_path; save_image -width 1920 /tmp/worst_path.png} false",
+};
+
+/**
+ * Reject a `gui::show` that would block the Tcl event loop forever.
+ *
+ * The argument-less form waits on a display and a human, so the session stays
+ * alive -- the process is running and isProcessAlive() reports true -- while
+ * every subsequent command times out. That is indistinguishable from a hang to
+ * the caller, and unrecoverable without terminating the session. `vwait` is in
+ * BLOCKED_COMMANDS for exactly this failure.
+ *
+ * The scripted form does not block: `gui::show <script> false` runs the script
+ * inside a transient GUI event loop and returns. ORFS uses it headlessly to
+ * write final_worst_path.webp (flow/scripts/final_report.tcl), so it has to
+ * keep working -- only the blocking shapes are rejected. `interactive`
+ * defaults to true, so an omitted flag blocks just as a `true` one does.
+ */
+function blocksEventLoop(command: string): string | null {
+  for (const stmt of splitTclStatements(command)) {
+    if (extractVerb(stmt) !== "gui::show") continue;
+    const args = stmt.trim().slice("gui::show".length).trim();
+    if (args.length === 0) return "gui::show";
+    if (!/(?:^|\s)(?:false|0)$/i.test(args)) return "gui::show";
+  }
+  return null;
+}
+
+/**
  * Check whether `command` is safe for the read-only query tool.
  *
  * A verb is allowed only when it matches READONLY_PATTERNS and is not in
@@ -334,6 +376,12 @@ function* iterVerbs(command: string): Generator<string> {
  * both treated as exec-only and are rejected here.
  */
 export function isQueryCommand(command: string): [boolean, string | null] {
+  const blocking = blocksEventLoop(command);
+  if (blocking !== null) {
+    logger.warn(`Blocked command '${blocking}' (would block the Tcl event loop)`);
+    return [false, blocking];
+  }
+
   for (const verb of iterVerbs(command)) {
     if (BLOCKED_COMMANDS.has(verb)) {
       logger.warn(`Blocked command '${verb}' (explicit blocklist)`);
@@ -361,6 +409,12 @@ export function isQueryCommand(command: string): [boolean, string | null] {
  * allowed; they will fail at the Tcl level if invalid.
  */
 export function isExecCommand(command: string): [boolean, string | null] {
+  const blocking = blocksEventLoop(command);
+  if (blocking !== null) {
+    logger.warn(`Blocked command '${blocking}' (would block the Tcl event loop)`);
+    return [false, blocking];
+  }
+
   for (const verb of iterVerbs(command)) {
     if (BLOCKED_COMMANDS.has(verb)) {
       logger.warn(`Blocked command '${verb}' (explicit blocklist)`);

--- a/typescript/src/config/settings.ts
+++ b/typescript/src/config/settings.ts
@@ -1,7 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 import fs from "node:fs";
-import { IMAGE_DEFAULTS } from "../constants.js";
+import { FLOW_RUN_DEFAULTS, IMAGE_DEFAULTS } from "../constants.js";
 
 const TRUTHY_VALUES = ["true", "1", "yes"];
 const FALSY_VALUES = ["false", "0", "no"];
@@ -68,6 +68,12 @@ export class Settings {
   readonly IMAGE_MAX_DIMENSION: number;
   /** Longest edge below which the resize ladder refuses to shrink further. */
   readonly IMAGE_MIN_DIMENSION: number;
+  /** Directory flow-run logs are streamed to. Never the session buffer. */
+  readonly RUN_LOG_DIR: string;
+  /** Concurrent flow runs allowed. */
+  readonly MAX_FLOW_JOBS: number;
+  /** Default wall-clock budget for a flow run, in seconds. */
+  readonly FLOW_RUN_TIMEOUT: number;
 
   constructor(overrides: Partial<Settings> = {}) {
     this.COMMAND_TIMEOUT = overrides.COMMAND_TIMEOUT ?? 30.0;
@@ -86,6 +92,9 @@ export class Settings {
     this.IMAGE_MAX_BASE64_KB = overrides.IMAGE_MAX_BASE64_KB ?? IMAGE_DEFAULTS.MAX_BASE64_KB;
     this.IMAGE_MAX_DIMENSION = overrides.IMAGE_MAX_DIMENSION ?? IMAGE_DEFAULTS.MAX_DIMENSION;
     this.IMAGE_MIN_DIMENSION = overrides.IMAGE_MIN_DIMENSION ?? IMAGE_DEFAULTS.MIN_DIMENSION;
+    this.RUN_LOG_DIR = overrides.RUN_LOG_DIR ?? path.join(os.tmpdir(), "openroad-mcp-runs");
+    this.MAX_FLOW_JOBS = overrides.MAX_FLOW_JOBS ?? FLOW_RUN_DEFAULTS.MAX_JOBS;
+    this.FLOW_RUN_TIMEOUT = overrides.FLOW_RUN_TIMEOUT ?? FLOW_RUN_DEFAULTS.TIMEOUT_SECONDS;
   }
 
   get flowPath(): string {
@@ -131,11 +140,14 @@ export class Settings {
       ["IMAGE_MAX_BASE64_KB", "OPENROAD_IMAGE_MAX_BASE64_KB", false],
       ["IMAGE_MAX_DIMENSION", "OPENROAD_IMAGE_MAX_DIMENSION", false],
       ["IMAGE_MIN_DIMENSION", "OPENROAD_IMAGE_MIN_DIMENSION", false],
+      ["MAX_FLOW_JOBS", "OPENROAD_MAX_FLOW_JOBS", false],
+      ["FLOW_RUN_TIMEOUT", "OPENROAD_FLOW_RUN_TIMEOUT", false],
     ];
     const strFields: Array<[keyof Settings, string]> = [
       ["LOG_LEVEL", "LOG_LEVEL"],
       ["LOG_FORMAT", "LOG_FORMAT"],
       ["ORFS_FLOW_PATH", "ORFS_FLOW_PATH"],
+      ["RUN_LOG_DIR", "OPENROAD_RUN_LOG_DIR"],
     ];
 
     for (const [field, envKey, allowZero] of floatFields) {

--- a/typescript/src/config/settings.ts
+++ b/typescript/src/config/settings.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 import fs from "node:fs";
+import { IMAGE_DEFAULTS } from "../constants.js";
 
 const TRUTHY_VALUES = ["true", "1", "yes"];
 const FALSY_VALUES = ["false", "0", "no"];
@@ -50,6 +51,23 @@ export class Settings {
   readonly ENABLE_COMMAND_VALIDATION: boolean;
   readonly WHITELIST_ENABLED: boolean;
   readonly ORFS_FLOW_PATH: string;
+  /**
+   * Budget for a report image, measured in KB of base64.
+   *
+   * This is the knob that decides whether a congestion or IR-drop heatmap is
+   * actually readable. The old 15 KB ceiling forced every image down to the
+   * 256x256 floor, which is useless for the heatmaps these tools exist to
+   * show.
+   */
+  readonly IMAGE_MAX_BASE64_KB: number;
+  /**
+   * Longest edge, in pixels, an image is resized down to before encoding.
+   * Defaults to the resolution ceiling vision models downsample to anyway --
+   * sending more pixels costs payload without adding detail.
+   */
+  readonly IMAGE_MAX_DIMENSION: number;
+  /** Longest edge below which the resize ladder refuses to shrink further. */
+  readonly IMAGE_MIN_DIMENSION: number;
 
   constructor(overrides: Partial<Settings> = {}) {
     this.COMMAND_TIMEOUT = overrides.COMMAND_TIMEOUT ?? 30.0;
@@ -65,6 +83,9 @@ export class Settings {
     this.ENABLE_COMMAND_VALIDATION = overrides.ENABLE_COMMAND_VALIDATION ?? true;
     this.WHITELIST_ENABLED = overrides.WHITELIST_ENABLED ?? true;
     this.ORFS_FLOW_PATH = overrides.ORFS_FLOW_PATH ?? path.join(os.homedir(), "OpenROAD-flow-scripts", "flow");
+    this.IMAGE_MAX_BASE64_KB = overrides.IMAGE_MAX_BASE64_KB ?? IMAGE_DEFAULTS.MAX_BASE64_KB;
+    this.IMAGE_MAX_DIMENSION = overrides.IMAGE_MAX_DIMENSION ?? IMAGE_DEFAULTS.MAX_DIMENSION;
+    this.IMAGE_MIN_DIMENSION = overrides.IMAGE_MIN_DIMENSION ?? IMAGE_DEFAULTS.MIN_DIMENSION;
   }
 
   get flowPath(): string {
@@ -107,6 +128,9 @@ export class Settings {
       ["MAX_SESSIONS", "OPENROAD_MAX_SESSIONS", false],
       ["SESSION_QUEUE_SIZE", "OPENROAD_SESSION_QUEUE_SIZE", false],
       ["READ_CHUNK_SIZE", "OPENROAD_READ_CHUNK_SIZE", false],
+      ["IMAGE_MAX_BASE64_KB", "OPENROAD_IMAGE_MAX_BASE64_KB", false],
+      ["IMAGE_MAX_DIMENSION", "OPENROAD_IMAGE_MAX_DIMENSION", false],
+      ["IMAGE_MIN_DIMENSION", "OPENROAD_IMAGE_MIN_DIMENSION", false],
     ];
     const strFields: Array<[keyof Settings, string]> = [
       ["LOG_LEVEL", "LOG_LEVEL"],

--- a/typescript/src/config/settings.ts
+++ b/typescript/src/config/settings.ts
@@ -1,7 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 import fs from "node:fs";
-import { FLOW_RUN_DEFAULTS, IMAGE_DEFAULTS } from "../constants.js";
+import { FLOW_RUN_DEFAULTS, IMAGE_DEFAULTS, OUTPUT_HISTORY_DEFAULTS } from "../constants.js";
 
 const TRUTHY_VALUES = ["true", "1", "yes"];
 const FALSY_VALUES = ["false", "0", "no"];
@@ -74,6 +74,10 @@ export class Settings {
   readonly MAX_FLOW_JOBS: number;
   /** Default wall-clock budget for a flow run, in seconds. */
   readonly FLOW_RUN_TIMEOUT: number;
+  /** Characters of recent command output retained per session for searching. */
+  readonly OUTPUT_HISTORY_CHARS: number;
+  /** Commands of output retained per session for searching. */
+  readonly OUTPUT_HISTORY_COMMANDS: number;
 
   constructor(overrides: Partial<Settings> = {}) {
     this.COMMAND_TIMEOUT = overrides.COMMAND_TIMEOUT ?? 30.0;
@@ -95,6 +99,9 @@ export class Settings {
     this.RUN_LOG_DIR = overrides.RUN_LOG_DIR ?? path.join(os.tmpdir(), "openroad-mcp-runs");
     this.MAX_FLOW_JOBS = overrides.MAX_FLOW_JOBS ?? FLOW_RUN_DEFAULTS.MAX_JOBS;
     this.FLOW_RUN_TIMEOUT = overrides.FLOW_RUN_TIMEOUT ?? FLOW_RUN_DEFAULTS.TIMEOUT_SECONDS;
+    this.OUTPUT_HISTORY_CHARS = overrides.OUTPUT_HISTORY_CHARS ?? OUTPUT_HISTORY_DEFAULTS.MAX_CHARS;
+    this.OUTPUT_HISTORY_COMMANDS =
+      overrides.OUTPUT_HISTORY_COMMANDS ?? OUTPUT_HISTORY_DEFAULTS.MAX_COMMANDS;
   }
 
   get flowPath(): string {
@@ -142,6 +149,8 @@ export class Settings {
       ["IMAGE_MIN_DIMENSION", "OPENROAD_IMAGE_MIN_DIMENSION", false],
       ["MAX_FLOW_JOBS", "OPENROAD_MAX_FLOW_JOBS", false],
       ["FLOW_RUN_TIMEOUT", "OPENROAD_FLOW_RUN_TIMEOUT", false],
+      ["OUTPUT_HISTORY_CHARS", "OPENROAD_OUTPUT_HISTORY_CHARS", true],
+      ["OUTPUT_HISTORY_COMMANDS", "OPENROAD_OUTPUT_HISTORY_COMMANDS", true],
     ];
     const strFields: Array<[keyof Settings, string]> = [
       ["LOG_LEVEL", "LOG_LEVEL"],

--- a/typescript/src/constants.ts
+++ b/typescript/src/constants.ts
@@ -20,6 +20,21 @@ export const SIGNIFICANT_LOG_THRESHOLD = 100_000;
 export const CHUNK_JOIN_THRESHOLD = 100;
 
 /**
+ * Flow-run defaults.
+ *
+ * A route on a real design runs for hours, so the default timeout is measured
+ * in hours rather than the seconds a Tcl command gets. MAX_JOBS is deliberately
+ * small: a flow run is far heavier than an interactive session, and nothing
+ * else on the server governs resource use.
+ */
+export const FLOW_RUN_DEFAULTS = {
+  TIMEOUT_SECONDS: 6 * 60 * 60,
+  MAX_JOBS: 2,
+  /** Grace period between SIGTERM and SIGKILL when tearing a run down. */
+  KILL_GRACE_MS: 5000,
+} as const;
+
+/**
  * Report-image budget defaults.
  *
  * MAX_BASE64_KB is the payload ceiling in KB of base64. The previous 15 KB

--- a/typescript/src/constants.ts
+++ b/typescript/src/constants.ts
@@ -19,6 +19,29 @@ export const SIGNIFICANT_LOG_THRESHOLD = 100_000;
 
 export const CHUNK_JOIN_THRESHOLD = 100;
 
+/**
+ * Banner prepended to any command output that lost characters to buffer
+ * overflow.
+ *
+ * The structured `truncated` / `bytes_discarded` fields carry the same fact,
+ * but a consumer reads `output` first: a result that silently begins mid-line
+ * reads as a complete answer, and has been acted on as one. Putting the notice
+ * in the text itself makes that mistake impossible.
+ */
+export function truncationNotice(
+  discarded: number,
+  total: number,
+  retained: number,
+): string {
+  const n = (v: number): string => v.toLocaleString("en-US");
+  return (
+    `[TRUNCATED: ${n(discarded)} of ${n(total)} characters were discarded from the START of this output.\n` +
+    ` What follows is the LAST ${n(retained)} characters only, and may begin mid-line. Any error or\n` +
+    ` warning printed before this point is NOT visible here. Narrow the query and re-run.]\n` +
+    `---\n`
+  );
+}
+
 export const LARGE_IO_THRESHOLD = 10_000;
 export const SLOW_OPERATION_THRESHOLD = 1.0;
 

--- a/typescript/src/constants.ts
+++ b/typescript/src/constants.ts
@@ -20,6 +20,19 @@ export const SIGNIFICANT_LOG_THRESHOLD = 100_000;
 export const CHUNK_JOIN_THRESHOLD = 100;
 
 /**
+ * Per-session retention of recent command output, so it can be searched after
+ * the fact.
+ *
+ * The circular buffer cannot serve this: runCommand drains it to empty, so a
+ * search over the live buffer finds nothing. Retention is capped by total
+ * characters and by number of commands, oldest evicted first.
+ */
+export const OUTPUT_HISTORY_DEFAULTS = {
+  MAX_CHARS: 256 * 1024,
+  MAX_COMMANDS: 50,
+} as const;
+
+/**
  * Flow-run defaults.
  *
  * A route on a real design runs for hours, so the default timeout is measured

--- a/typescript/src/constants.ts
+++ b/typescript/src/constants.ts
@@ -20,6 +20,23 @@ export const SIGNIFICANT_LOG_THRESHOLD = 100_000;
 export const CHUNK_JOIN_THRESHOLD = 100;
 
 /**
+ * Report-image budget defaults.
+ *
+ * MAX_BASE64_KB is the payload ceiling in KB of base64. The previous 15 KB
+ * ceiling forced every render down to the resize floor -- a 1099x1099 image
+ * became 256x256 -- which is unreadable for the congestion and IR-drop
+ * heatmaps these tools exist to show.
+ *
+ * MAX_DIMENSION is the longest edge worth sending: vision models downsample
+ * beyond roughly this, so extra pixels cost payload without adding detail.
+ */
+export const IMAGE_DEFAULTS = {
+  MAX_BASE64_KB: 1024,
+  MAX_DIMENSION: 1568,
+  MIN_DIMENSION: 512,
+} as const;
+
+/**
  * Banner prepended to any command output that lost characters to buffer
  * overflow.
  *

--- a/typescript/src/core/flow_jobs.ts
+++ b/typescript/src/core/flow_jobs.ts
@@ -1,0 +1,333 @@
+import { spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { getSettings } from "../config/settings.js";
+import { FLOW_RUN_DEFAULTS } from "../constants.js";
+import {
+  DEFAULT_RECENT_LINES,
+  detectCurrentStage,
+  parseRunProgress,
+  readLogTail,
+  readLogTailText,
+} from "../flow/run_progress.js";
+import type { RunProgress } from "../flow/run_progress.js";
+import { getLogger } from "../utils/logging.js";
+
+const logger = getLogger("flow.jobs");
+
+export type FlowJobStatus = "running" | "succeeded" | "failed" | "cancelled" | "timed_out";
+
+export interface FlowJobSpec {
+  platform: string;
+  design: string;
+  variant: string;
+  target: string;
+  overrides: Record<string, string>;
+  jobs?: number | undefined;
+  dryRun?: boolean | undefined;
+  timeoutSeconds?: number | undefined;
+}
+
+export interface FlowJob {
+  jobId: string;
+  spec: FlowJobSpec;
+  argv: string[];
+  status: FlowJobStatus;
+  exitCode: number | null;
+  signal: string | null;
+  startedAt: string;
+  finishedAt: string | null;
+  logPath: string;
+  statusPath: string;
+  logsDir: string;
+  pid: number | null;
+  error: string | null;
+}
+
+/** Build the make argv. Assignments go on the command line, where they beat both the environment and the Makefile. */
+export function buildMakeArgv(spec: FlowJobSpec): string[] {
+  const argv: string[] = [];
+  if (spec.dryRun === true) argv.push("-n");
+  if (spec.jobs !== undefined && spec.jobs > 0) argv.push(`-j${spec.jobs}`);
+  argv.push(spec.target);
+  argv.push(`DESIGN_CONFIG=./designs/${spec.platform}/${spec.design}/config.mk`);
+  argv.push(`FLOW_VARIANT=${spec.variant}`);
+  for (const [key, value] of Object.entries(spec.overrides)) {
+    argv.push(`${key}=${value}`);
+  }
+  return argv;
+}
+
+export class FlowJobLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FlowJobLimitError";
+  }
+}
+
+export class FlowJobNotFoundError extends Error {
+  constructor(jobId: string) {
+    super(`Flow job '${jobId}' not found`);
+    this.name = "FlowJobNotFoundError";
+  }
+}
+
+/**
+ * Tracks `make` runs of ORFS stages.
+ *
+ * Output is streamed straight to a file, never through the session's 128 KB
+ * circular buffer: a route log runs to tens of MB, so the buffer would discard
+ * everything but the tail.
+ */
+export class FlowJobRegistry {
+  private readonly jobs = new Map<string, FlowJob>();
+  private readonly children = new Map<string, ChildProcess>();
+  private readonly waiters = new Map<string, Array<() => void>>();
+  private readonly timers = new Map<string, NodeJS.Timeout>();
+
+  constructor(private readonly makeBinary = "make") {}
+
+  get size(): number {
+    return this.jobs.size;
+  }
+
+  activeCount(): number {
+    let n = 0;
+    for (const job of this.jobs.values()) if (job.status === "running") n += 1;
+    return n;
+  }
+
+  start(spec: FlowJobSpec, cwd: string): FlowJob {
+    const settings = getSettings();
+    const maxJobs = settings.MAX_FLOW_JOBS ?? FLOW_RUN_DEFAULTS.MAX_JOBS;
+    if (this.activeCount() >= maxJobs) {
+      throw new FlowJobLimitError(
+        `${this.activeCount()} flow run(s) already in progress (limit ${maxJobs}). ` +
+          `Wait for one to finish or cancel it, or raise OPENROAD_MAX_FLOW_JOBS.`,
+      );
+    }
+
+    const jobId = randomUUID().slice(0, 8);
+    const logDir = settings.RUN_LOG_DIR;
+    fs.mkdirSync(logDir, { recursive: true });
+    const logPath = path.join(logDir, `${jobId}.log`);
+    const statusPath = path.join(logDir, `${jobId}.status`);
+    const argv = buildMakeArgv(spec);
+
+    const job: FlowJob = {
+      jobId,
+      spec,
+      argv: [this.makeBinary, ...argv],
+      status: "running",
+      exitCode: null,
+      signal: null,
+      startedAt: new Date().toISOString(),
+      finishedAt: null,
+      logPath,
+      statusPath,
+      logsDir: path.join(cwd, "logs", spec.platform, spec.design, spec.variant),
+      pid: null,
+      error: null,
+    };
+    this.jobs.set(jobId, job);
+
+    const stream = fs.createWriteStream(logPath, { flags: "a" });
+    stream.write(`$ ${this.makeBinary} ${argv.join(" ")}\n`);
+
+    let child: ChildProcess;
+    try {
+      child = spawn(this.makeBinary, argv, {
+        cwd,
+        // No shell: overrides reach make as argv entries, never as something a
+        // shell could reinterpret. Detached so the run gets its own process
+        // group -- killing only `make` would strand the grandchild openroad,
+        // exactly the orphan case scenario 10 found on this host.
+        shell: false,
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (e) {
+      stream.end();
+      this._finish(job, "failed", null, null, (e as Error).message);
+      return job;
+    }
+
+    job.pid = child.pid ?? null;
+    this.children.set(jobId, child);
+    child.stdout?.pipe(stream, { end: false });
+    child.stderr?.pipe(stream, { end: false });
+
+    child.on("error", (err) => {
+      stream.end();
+      this._finish(job, "failed", null, null, err.message);
+    });
+
+    child.on("close", (code, signal) => {
+      stream.end();
+      const status: FlowJobStatus =
+        job.status === "cancelled" || job.status === "timed_out"
+          ? job.status
+          : code === 0
+            ? "succeeded"
+            : "failed";
+      this._finish(job, status, code, signal, null);
+    });
+
+    const timeoutSeconds = spec.timeoutSeconds ?? settings.FLOW_RUN_TIMEOUT;
+    if (timeoutSeconds > 0) {
+      const timer = setTimeout(() => {
+        if (job.status !== "running") return;
+        job.status = "timed_out";
+        job.error = `Flow run exceeded ${timeoutSeconds}s and was terminated`;
+        this._killTree(jobId);
+      }, timeoutSeconds * 1000);
+      // A pending run must not hold the process open on shutdown.
+      timer.unref?.();
+      this.timers.set(jobId, timer);
+    }
+
+    logger.info(`Started flow job ${jobId}: make ${argv.join(" ")}`);
+    return job;
+  }
+
+  get(jobId: string): FlowJob {
+    const job = this.jobs.get(jobId);
+    if (job === undefined) throw new FlowJobNotFoundError(jobId);
+    return job;
+  }
+
+  list(): FlowJob[] {
+    return [...this.jobs.values()];
+  }
+
+  /** Signal the whole process group, escalating to SIGKILL after a grace period. */
+  cancel(jobId: string): FlowJob {
+    const job = this.get(jobId);
+    if (job.status !== "running") return job;
+    job.status = "cancelled";
+    job.error = "Cancelled by request";
+    this._killTree(jobId);
+    return job;
+  }
+
+  /** Resolve once the job leaves `running`, or after `timeoutMs`. */
+  async waitFor(jobId: string, timeoutMs: number): Promise<FlowJob> {
+    const job = this.get(jobId);
+    if (job.status !== "running" || timeoutMs <= 0) return job;
+
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      const done = (): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(done, timeoutMs);
+      timer.unref?.();
+      const list = this.waiters.get(jobId) ?? [];
+      list.push(done);
+      this.waiters.set(jobId, list);
+    });
+
+    return this.get(jobId);
+  }
+
+  /** Live progress plus the tail of the run log. */
+  inspect(jobId: string, recentLines = DEFAULT_RECENT_LINES): {
+    job: FlowJob;
+    progress: RunProgress;
+    recentLines: string[];
+    logBytes: number;
+    logTruncated: boolean;
+    elapsedSeconds: number;
+  } {
+    const job = this.get(jobId);
+    const tail = readLogTail(job.logPath, recentLines);
+    const stage = detectCurrentStage(job.logsDir);
+    const end = job.finishedAt === null ? Date.now() : Date.parse(job.finishedAt);
+
+    return {
+      job,
+      progress: parseRunProgress(readLogTailText(job.logPath), stage),
+      recentLines: tail.lines,
+      logBytes: tail.totalBytes,
+      logTruncated: tail.truncated,
+      elapsedSeconds: Math.max(0, (end - Date.parse(job.startedAt)) / 1000),
+    };
+  }
+
+  /** Terminate every running job. Used on server shutdown. */
+  async shutdown(): Promise<void> {
+    for (const job of this.jobs.values()) {
+      if (job.status === "running") {
+        job.status = "cancelled";
+        job.error = "Server shutting down";
+        this._killTree(job.jobId);
+      }
+    }
+  }
+
+  private _killTree(jobId: string): void {
+    const child = this.children.get(jobId);
+    const job = this.jobs.get(jobId);
+    if (child === undefined || job?.pid == null) return;
+
+    // Negative pid targets the process group, so make's children -- the
+    // openroad processes actually doing the work -- go down with it.
+    const signalGroup = (signal: NodeJS.Signals): void => {
+      try {
+        process.kill(-job.pid!, signal);
+      } catch {
+        try {
+          child.kill(signal);
+        } catch {
+          /* already gone */
+        }
+      }
+    };
+
+    signalGroup("SIGTERM");
+    const killTimer = setTimeout(() => {
+      if (this.children.has(jobId)) signalGroup("SIGKILL");
+    }, FLOW_RUN_DEFAULTS.KILL_GRACE_MS);
+    killTimer.unref?.();
+  }
+
+  private _finish(
+    job: FlowJob,
+    status: FlowJobStatus,
+    code: number | null,
+    signal: NodeJS.Signals | string | null,
+    error: string | null,
+  ): void {
+    if (job.finishedAt !== null) return;
+    job.status = status;
+    job.exitCode = code;
+    job.signal = signal === null ? null : String(signal);
+    job.finishedAt = new Date().toISOString();
+    if (error !== null) job.error = error;
+
+    const timer = this.timers.get(job.jobId);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      this.timers.delete(job.jobId);
+    }
+    this.children.delete(job.jobId);
+
+    // Mirrors the .orfs-eval-logs/*.status convention already in the repo.
+    try {
+      fs.writeFileSync(job.statusPath, `RC=${code ?? ""}\nSTATUS=${status}\n`);
+    } catch {
+      /* best effort */
+    }
+
+    for (const resolve of this.waiters.get(job.jobId) ?? []) resolve();
+    this.waiters.delete(job.jobId);
+    logger.info(`Flow job ${job.jobId} ${status} (exit ${String(code)})`);
+  }
+}
+
+export const flowJobs = new FlowJobRegistry();

--- a/typescript/src/core/flow_jobs.ts
+++ b/typescript/src/core/flow_jobs.ts
@@ -142,7 +142,9 @@ export class FlowJobRegistry {
     // above. A stream error with no listener is an uncaught exception that
     // takes the server down, so record it on the job and let the run continue:
     // losing the log is not a reason to lose the run.
+    let streamFailed = false;
     stream.on("error", (err: Error) => {
+      streamFailed = true;
       job.logWritable = false;
       if (job.error === null) job.error = `Run log unavailable: ${err.message}`;
       logger.warn(`Flow job ${jobId}: run log ${logPath} could not be written: ${err.message}`);
@@ -178,14 +180,31 @@ export class FlowJobRegistry {
     });
 
     child.on("close", (code, signal) => {
-      stream.end();
       const status: FlowJobStatus =
         job.status === "cancelled" || job.status === "timed_out"
           ? job.status
           : code === 0
             ? "succeeded"
             : "failed";
-      this._finish(job, status, code, signal, null);
+
+      // Finish only once the log has actually flushed. The child closing says
+      // nothing about the pipe into the file being drained, so reporting the
+      // job done here lets a caller poll immediately and read a partial log --
+      // a truncated result that looks complete.
+      let settled = false;
+      const done = (): void => {
+        if (settled) return;
+        settled = true;
+        this._finish(job, status, code, signal, null);
+      };
+
+      if (streamFailed || stream.destroyed) {
+        done();
+        return;
+      }
+      // An errored stream never emits `finish`, so listen for both.
+      stream.once("error", done);
+      stream.end(done);
     });
 
     const timeoutSeconds = spec.timeoutSeconds ?? settings.FLOW_RUN_TIMEOUT;

--- a/typescript/src/core/flow_jobs.ts
+++ b/typescript/src/core/flow_jobs.ts
@@ -43,6 +43,8 @@ export interface FlowJob {
   statusPath: string;
   logsDir: string;
   pid: number | null;
+  /** False once the run log could not be written; progress goes blind, the run does not. */
+  logWritable: boolean;
   error: string | null;
 }
 
@@ -129,11 +131,22 @@ export class FlowJobRegistry {
       statusPath,
       logsDir: path.join(cwd, "logs", spec.platform, spec.design, spec.variant),
       pid: null,
+      logWritable: true,
       error: null,
     };
     this.jobs.set(jobId, job);
 
     const stream = fs.createWriteStream(logPath, { flags: "a" });
+    // createWriteStream opens asynchronously, so a log path that is unwritable
+    // -- removed, out of space, permissions -- surfaces here rather than
+    // above. A stream error with no listener is an uncaught exception that
+    // takes the server down, so record it on the job and let the run continue:
+    // losing the log is not a reason to lose the run.
+    stream.on("error", (err: Error) => {
+      job.logWritable = false;
+      if (job.error === null) job.error = `Run log unavailable: ${err.message}`;
+      logger.warn(`Flow job ${jobId}: run log ${logPath} could not be written: ${err.message}`);
+    });
     stream.write(`$ ${this.makeBinary} ${argv.join(" ")}\n`);
 
     let child: ChildProcess;

--- a/typescript/src/core/manager.ts
+++ b/typescript/src/core/manager.ts
@@ -12,6 +12,7 @@ import type {
   InteractiveSessionInfo,
   ManagerMetrics,
   SessionDetailedMetrics,
+  SessionGrepResult,
 } from "./models.js";
 
 /** Time after which a dead session is force-removed even if cleanup fails. */
@@ -182,6 +183,14 @@ export class OpenROADManager {
 
   async filterSessionOutput(sessionId: string, pattern: string, maxLines = 1000): Promise<string[]> {
     return this._getSession(sessionId).filterOutput(pattern, maxLines);
+  }
+
+  async grepSessionOutput(
+    sessionId: string,
+    pattern: string,
+    opts: { maxMatches?: number; contextLines?: number; ignoreCase?: boolean; commandNumber?: number } = {},
+  ): Promise<SessionGrepResult> {
+    return this._getSession(sessionId).grepOutput(pattern, opts);
   }
 
   async setSessionTimeout(sessionId: string, timeoutSeconds: number): Promise<void> {

--- a/typescript/src/core/models.ts
+++ b/typescript/src/core/models.ts
@@ -170,6 +170,62 @@ export const SessionMetricsResult = z.object({
 });
 export type SessionMetricsResult = z.infer<typeof SessionMetricsResult>;
 
+// Session output search models
+
+/** One retained command output, searchable after the command has returned. */
+export interface SessionOutputRecord {
+  commandNumber: number;
+  command: string;
+  timestamp: string;
+  output: string;
+  /** True when the result was larger than the retention budget and lost its head. */
+  truncated: boolean;
+}
+
+export interface SessionGrepMatch {
+  commandNumber: number;
+  command: string;
+  /** 1-based line number within that command's output. */
+  lineNumber: number;
+  line: string;
+  before?: string[];
+  after?: string[];
+}
+
+export interface SessionGrepResult {
+  matches: SessionGrepMatch[];
+  /** Matches found, which exceeds matches.length when capped. */
+  totalMatches: number;
+  truncated: boolean;
+  /**
+   * How the pattern was applied: as a regex, as a literal because it did not
+   * compile, or as a literal after the regex matched nothing (a pasted net
+   * name like `dpath.a_reg[0]` is valid regex that matches nothing).
+   */
+  patternKind: "regex" | "substring" | "substring-fallback";
+  searchedCommands: number;
+  searchedLines: number;
+  retainedChars: number;
+  /** Commands whose output was evicted to stay inside the retention budget. */
+  evictedCommands: number;
+}
+
+export const SessionGrepOutputResult = z.object({
+  sessionId: z.string().nullable().default(null),
+  pattern: z.string().nullable().default(null),
+  matches: z.array(z.custom<SessionGrepMatch>()).default([]),
+  totalMatches: z.number().default(0),
+  truncated: z.boolean().default(false),
+  patternKind: z.string().nullable().default(null),
+  searchedCommands: z.number().default(0),
+  searchedLines: z.number().default(0),
+  retainedChars: z.number().default(0),
+  evictedCommands: z.number().default(0),
+  message: z.string().nullable().default(null),
+  error: errorField,
+});
+export type SessionGrepOutputResult = z.infer<typeof SessionGrepOutputResult>;
+
 // ORFS metrics models
 
 /** One stage's metrics file, as read from logs/<platform>/<design>/<variant>. */

--- a/typescript/src/core/models.ts
+++ b/typescript/src/core/models.ts
@@ -35,7 +35,26 @@ export interface InteractiveExecResult {
   timestamp: string;
   executionTime: number;
   commandCount: number;
+  /**
+   * The session buffer's capacity in characters -- the ceiling that
+   * `bytesDiscarded` was measured against.
+   *
+   * Note this differs from InteractiveSessionInfo.bufferSize, which is the
+   * live residual buffer. Reporting the residual here was useless: a command
+   * result is produced only after the buffer has been drained, so the field
+   * was structurally always 0.
+   */
   bufferSize: number;
+  /** True when output exceeded the buffer and the head was thrown away. */
+  truncated: boolean;
+  /** Characters dropped from the START of the output. 0 when complete. */
+  bytesDiscarded: number;
+  /**
+   * Total raw characters the command produced, before ANSI and sentinel
+   * cleaning. Slightly exceeds output.length + bytesDiscarded on a truncated
+   * result; the difference is escape sequences and plumbing, not lost content.
+   */
+  totalBytes: number;
   error?: string | null;
 }
 

--- a/typescript/src/core/models.ts
+++ b/typescript/src/core/models.ts
@@ -170,6 +170,47 @@ export const SessionMetricsResult = z.object({
 });
 export type SessionMetricsResult = z.infer<typeof SessionMetricsResult>;
 
+// ORFS metrics models
+
+/** One stage's metrics file, as read from logs/<platform>/<design>/<variant>. */
+export interface OrfsStageMetrics {
+  stage: string;
+  metricsPath: string | null;
+  metrics: Record<string, unknown>;
+  /**
+   * Metric keys the file recorded more than once, whose values are therefore
+   * arrays. ORFS appends a block per sub-run, so this is normal rather than
+   * corruption -- but a caller must know which keys are arrays.
+   */
+  repeatedMetrics: string[];
+  log: {
+    path: string;
+    errors: string[];
+    warnings: string[];
+    errorCount: number;
+    warningCount: number;
+    truncated: boolean;
+  } | null;
+  error?: string | null;
+}
+
+export const OrfsMetricsResult = z.object({
+  platform: z.string().nullable().default(null),
+  design: z.string().nullable().default(null),
+  variant: z.string().nullable().default(null),
+  stage: z.string().nullable().default(null),
+  logsPath: z.string().nullable().default(null),
+  stages: z.array(z.custom<OrfsStageMetrics>()).default([]),
+  availableStages: z.array(z.string()).default([]),
+  gates: z.array(z.custom<unknown>()).default([]),
+  unmatchedGates: z.array(z.custom<unknown>()).default([]),
+  gateSummary: z.custom<unknown>().nullable().default(null),
+  rulesPath: z.string().nullable().default(null),
+  message: z.string().nullable().default(null),
+  error: errorField,
+});
+export type OrfsMetricsResult = z.infer<typeof OrfsMetricsResult>;
+
 // Image models
 
 export const ImageInfo = z.object({

--- a/typescript/src/flow/run_progress.ts
+++ b/typescript/src/flow/run_progress.ts
@@ -1,0 +1,162 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * How much of the tail of a run log is read on each poll. A route log runs to
+ * tens of MB and is polled repeatedly, so the whole file is never read.
+ */
+export const LOG_TAIL_BYTES = 64 * 1024;
+
+/** Default number of trailing log lines returned to a caller. */
+export const DEFAULT_RECENT_LINES = 50;
+
+// Progress markers, verified against the real ibex route log from scenario 8.
+const ITERATION_LINE = /Start (\d+)(?:st|nd|rd|th) optimization iteration/g;
+const COMPLETING_LINE = /Completing (\d+)% with (\d+) violations/g;
+const VIOLATION_TOTAL_LINE = /Number of violations = (\d+)/g;
+// [INFO DRT-0267] cpu time = 00:00:13, elapsed time = 00:00:04, memory = 557.72 (MB), peak = 570.05 (MB)
+const RESOURCE_LINE =
+  /cpu time = (\d+):(\d+):(\d+), elapsed time = (\d+):(\d+):(\d+), memory = ([\d.]+) \(MB\), peak = ([\d.]+) \(MB\)/g;
+
+/** Last capture of a global regex, or null when it never matched. */
+function lastMatch(text: string, re: RegExp): RegExpMatchArray | null {
+  re.lastIndex = 0;
+  let last: RegExpMatchArray | null = null;
+  for (;;) {
+    const m = re.exec(text);
+    if (m === null) return last;
+    last = m;
+  }
+}
+
+function toSeconds(h: string, m: string, s: string): number {
+  return Number(h) * 3600 + Number(m) * 60 + Number(s);
+}
+
+export interface RunProgress {
+  /** ORFS stage currently executing, from the newest *.tmp.log. */
+  currentStage: string | null;
+  /** Detailed-route optimization iteration, when routing. */
+  iteration: number | null;
+  /** Percent through the current iteration. */
+  percent: number | null;
+  /** Live DRC violation count from the most recent progress line. */
+  violations: number | null;
+  /** Violation total reported at the end of an iteration. */
+  iterationViolations: number | null;
+  cpuSeconds: number | null;
+  elapsedSeconds: number | null;
+  memoryMb: number | null;
+  peakMemoryMb: number | null;
+}
+
+/**
+ * Derive structured progress from a run log tail.
+ *
+ * Scenario 8 backgrounded `make route` and was, in its own words, "reduced to
+ * tail/grep-ing a raw log and ps/stat-ing files". These are the same signals it
+ * was grepping for by hand, parsed once and served properly.
+ *
+ * CPU and memory come from OpenROAD's own DRT-0267 line rather than from
+ * `pidusage` on the make pid: pidusage does not aggregate children, and the
+ * process actually consuming the machine is a grandchild `openroad`.
+ */
+export function parseRunProgress(tail: string, currentStage: string | null): RunProgress {
+  const iterationMatch = lastMatch(tail, ITERATION_LINE);
+  const completingMatch = lastMatch(tail, COMPLETING_LINE);
+  const violationMatch = lastMatch(tail, VIOLATION_TOTAL_LINE);
+  const resourceMatch = lastMatch(tail, RESOURCE_LINE);
+
+  return {
+    currentStage,
+    iteration: iterationMatch ? Number(iterationMatch[1]) : null,
+    percent: completingMatch ? Number(completingMatch[1]) : null,
+    violations: completingMatch ? Number(completingMatch[2]) : null,
+    iterationViolations: violationMatch ? Number(violationMatch[1]) : null,
+    cpuSeconds: resourceMatch
+      ? toSeconds(resourceMatch[1]!, resourceMatch[2]!, resourceMatch[3]!)
+      : null,
+    elapsedSeconds: resourceMatch
+      ? toSeconds(resourceMatch[4]!, resourceMatch[5]!, resourceMatch[6]!)
+      : null,
+    memoryMb: resourceMatch ? Number(resourceMatch[7]) : null,
+    peakMemoryMb: resourceMatch ? Number(resourceMatch[8]) : null,
+  };
+}
+
+/**
+ * The stage ORFS is running right now.
+ *
+ * ORFS writes each stage through `run_command.py --log .../<stem>.tmp.log
+ * --append --tee`, renaming it to `<stem>.log` once the stage succeeds. So the
+ * newest `.tmp.log` names the stage in flight. Reading that rather than
+ * parsing make's echoed recipe keeps this working across ORFS releases that
+ * renumber their stages.
+ */
+export function detectCurrentStage(logsDir: string): string | null {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(logsDir);
+  } catch {
+    return null;
+  }
+
+  let newest: { stem: string; mtimeMs: number } | null = null;
+  for (const entry of entries) {
+    if (!entry.endsWith(".tmp.log")) continue;
+    const stem = entry.slice(0, -".tmp.log".length);
+    try {
+      const { mtimeMs } = fs.statSync(path.join(logsDir, entry));
+      if (newest === null || mtimeMs > newest.mtimeMs) newest = { stem, mtimeMs };
+    } catch {
+      /* raced with the rename to .log; skip it */
+    }
+  }
+  return newest?.stem ?? null;
+}
+
+export interface LogTail {
+  lines: string[];
+  /** Total bytes in the log, not just the portion read. */
+  totalBytes: number;
+  /** True when the log holds more than the lines returned. */
+  truncated: boolean;
+}
+
+/** Read the last `maxLines` lines of a log without loading the whole file. */
+export function readLogTail(logPath: string, maxLines = DEFAULT_RECENT_LINES): LogTail {
+  let fd: number;
+  let totalBytes: number;
+  try {
+    totalBytes = fs.statSync(logPath).size;
+    fd = fs.openSync(logPath, "r");
+  } catch {
+    return { lines: [], totalBytes: 0, truncated: false };
+  }
+
+  try {
+    const readBytes = Math.min(totalBytes, LOG_TAIL_BYTES);
+    const buffer = Buffer.allocUnsafe(readBytes);
+    fs.readSync(fd, buffer, 0, readBytes, totalBytes - readBytes);
+    const text = buffer.toString("utf8");
+    // A partial read almost certainly starts mid-line; drop that fragment
+    // rather than presenting a truncated line as a whole one.
+    const all = text.split(/\r?\n/);
+    if (readBytes < totalBytes && all.length > 0) all.shift();
+    while (all.length > 0 && all[all.length - 1] === "") all.pop();
+
+    const lines = all.slice(-maxLines);
+    return {
+      lines,
+      totalBytes,
+      truncated: readBytes < totalBytes || all.length > lines.length,
+    };
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+/** Read the tail as raw text, for the progress parser. */
+export function readLogTailText(logPath: string): string {
+  return readLogTail(logPath, Number.MAX_SAFE_INTEGER).lines.join("\n");
+}

--- a/typescript/src/interactive/buffer.ts
+++ b/typescript/src/interactive/buffer.ts
@@ -6,6 +6,7 @@ export class CircularBuffer {
   readonly maxSize: number;
   private readonly _chunks: string[] = [];
   private _totalSize = 0;
+  private _discardedChars = 0;
   private readonly _mutex = new Mutex();
   private _dataAvailable = false;
   private _resolvers: Array<(available: boolean) => void> = [];
@@ -22,6 +23,16 @@ export class CircularBuffer {
     return this._chunks.length;
   }
 
+  /**
+   * Characters dropped on overflow since the last takeDiscarded().
+   *
+   * Overflow silently deletes the oldest output, so a caller that does not
+   * know this number cannot tell a complete result from a mutilated one.
+   */
+  get discardedChars(): number {
+    return this._discardedChars;
+  }
+
   async append(data: string): Promise<void> {
     if (!data) return;
 
@@ -35,6 +46,7 @@ export class CircularBuffer {
       while (this._totalSize > this.maxSize && this._chunks.length > 1) {
         const old = this._chunks.shift()!;
         this._totalSize -= old.length;
+        this._discardedChars += old.length;
       }
 
       // A single chunk larger than maxSize is truncated to its last maxSize
@@ -42,12 +54,29 @@ export class CircularBuffer {
       if (this._totalSize > this.maxSize) {
         const chunk = this._chunks[0]!;
         this._chunks[0] = chunk.slice(chunk.length - this.maxSize);
+        this._discardedChars += chunk.length - this.maxSize;
         this._totalSize = this.maxSize;
       }
 
       this._dataAvailable = true;
       const pending = this._resolvers.splice(0);
       for (const resolve of pending) resolve(true);
+    } finally {
+      release();
+    }
+  }
+
+  /**
+   * Return the discard count and reset it, so the next command starts from
+   * zero. Per-command accounting needs a reset point: a cumulative-only
+   * counter would report a previous command's loss as this one's.
+   */
+  async takeDiscarded(): Promise<number> {
+    const release = await this._mutex.acquire();
+    try {
+      const discarded = this._discardedChars;
+      this._discardedChars = 0;
+      return discarded;
     } finally {
       release();
     }
@@ -137,6 +166,7 @@ export class CircularBuffer {
     chunkCount: number;
     maxSize: number;
     utilizationPercent: number;
+    discardedChars: number;
   }> {
     const release = await this._mutex.acquire();
     try {
@@ -146,6 +176,7 @@ export class CircularBuffer {
         maxSize: this.maxSize,
         utilizationPercent:
           this.maxSize > 0 ? Math.floor((this._totalSize / this.maxSize) * 100) : 0,
+        discardedChars: this._discardedChars,
       };
     } finally {
       release();

--- a/typescript/src/interactive/session.ts
+++ b/typescript/src/interactive/session.ts
@@ -286,7 +286,7 @@ export class InteractiveSession {
    * results that were never computed.
    */
   async verifyResponsive(timeoutMs = 15000): Promise<void> {
-    const result = await this.runCommand(PROBE_COMMAND, timeoutMs);
+    const result = await this.runCommand(PROBE_COMMAND, timeoutMs, false);
     if (!result.output.includes(PROBE_TOKEN)) {
       throw new SessionError(
         `Session ${this.sessionId} started but is not executing commands: the OpenROAD ` +
@@ -311,8 +311,16 @@ export class InteractiveSession {
    * PTY's echo as a successful result for anything slower than a few
    * milliseconds. This waits for an explicit sentinel and reports a real error
    * when the command does not finish inside timeoutMs.
+   *
+   * `retain` exists for the startup probe, which is plumbing rather than user
+   * activity: its output must not be searchable and must not consume any of
+   * the retention budget.
    */
-  async runCommand(command: string, timeoutMs = 30000): Promise<InteractiveExecResult> {
+  async runCommand(
+    command: string,
+    timeoutMs = 30000,
+    retain = true,
+  ): Promise<InteractiveExecResult> {
     const startTime = Date.now();
 
     if (!this.checkAlive()) {
@@ -353,7 +361,7 @@ export class InteractiveSession {
 
     await this._updatePerformanceMetrics();
     this._recordReadResult(output.length, executionTime);
-    this._retainOutput(command, output);
+    if (retain) this._retainOutput(command, output);
 
     // An incomplete result outranks anything matched inside it: a command that
     // printed "Error:" and then kept running must not look like it finished.

--- a/typescript/src/interactive/session.ts
+++ b/typescript/src/interactive/session.ts
@@ -6,6 +6,11 @@ import { getSettings } from "../config/settings.js";
 import type { Settings } from "../config/settings.js";
 import { SessionState } from "../core/models.js";
 import type {
+  SessionGrepMatch,
+  SessionGrepResult,
+  SessionOutputRecord,
+} from "../core/models.js";
+import type {
   CommandHistoryEntry,
   InteractiveExecResult,
   InteractiveSessionInfo,
@@ -15,6 +20,7 @@ import {
   BYTES_TO_MB,
   MAX_COMMAND_COMPLETION_WINDOW,
   MAX_COMMAND_HISTORY,
+  OUTPUT_HISTORY_DEFAULTS,
   PTY_LINE_TERMINATOR,
   truncationNotice,
   UTILIZATION_PERCENTAGE_BASE,
@@ -108,6 +114,19 @@ export class InteractiveSession {
   // Serialises terminate()/cleanup() so concurrent callers cannot double-kill
   // the process or deliver a stale exit code to waiters.
   private readonly _lifecycleLock = new Mutex();
+
+  /**
+   * Recent command output, kept so it can be searched after the fact.
+   *
+   * runCommand drains the circular buffer to empty, so anything searching the
+   * live buffer finds nothing once a command has returned. Retaining the
+   * cleaned output here is what makes grep over a session's results possible
+   * without re-running the command or re-sending a large result.
+   */
+  private readonly _outputHistory: SessionOutputRecord[] = [];
+  private _outputHistoryChars = 0;
+  /** Records dropped to stay inside the retention budget. */
+  private _outputHistoryEvicted = 0;
 
   constructor(sessionId: string, bufferSize?: number, private readonly _settings: Settings = getSettings()) {
     this.sessionId = sessionId;
@@ -334,6 +353,7 @@ export class InteractiveSession {
 
     await this._updatePerformanceMetrics();
     this._recordReadResult(output.length, executionTime);
+    this._retainOutput(command, output);
 
     // An incomplete result outranks anything matched inside it: a command that
     // printed "Error:" and then kept running must not look like it finished.
@@ -791,23 +811,147 @@ export class InteractiveSession {
     return idleTime > idleThresholdSeconds;
   }
 
-  async filterOutput(pattern: string, maxLines = 1000): Promise<string[]> {
-    const chunks = await this.outputBuffer.peekAll();
-    if (chunks.length === 0) return [];
+  /** Keep a command's output for later searching, oldest evicted first. */
+  private _retainOutput(command: string, output: string): void {
+    if (output.length === 0) return;
 
-    const text = this.outputBuffer.toText(chunks);
-    const lines = text.split("\n");
+    const maxChars = this._settings.OUTPUT_HISTORY_CHARS ?? OUTPUT_HISTORY_DEFAULTS.MAX_CHARS;
+    const maxCommands =
+      this._settings.OUTPUT_HISTORY_COMMANDS ?? OUTPUT_HISTORY_DEFAULTS.MAX_COMMANDS;
+    if (maxChars <= 0 || maxCommands <= 0) return;
 
-    let matching: string[];
+    // A single result larger than the whole budget keeps its tail, matching
+    // how the output buffer itself sheds the head.
+    const kept = output.length > maxChars ? output.slice(output.length - maxChars) : output;
+
+    this._outputHistory.push({
+      commandNumber: this.commandCount,
+      command,
+      timestamp: new Date().toISOString(),
+      output: kept,
+      truncated: kept.length < output.length,
+    });
+    this._outputHistoryChars += kept.length;
+
+    while (
+      this._outputHistory.length > maxCommands ||
+      (this._outputHistoryChars > maxChars && this._outputHistory.length > 1)
+    ) {
+      const dropped = this._outputHistory.shift()!;
+      this._outputHistoryChars -= dropped.output.length;
+      this._outputHistoryEvicted += 1;
+    }
+  }
+
+  /**
+   * Search retained command output, plus anything still sitting unread in the
+   * live buffer.
+   *
+   * `pattern` is treated as a regular expression, falling back to a substring
+   * search when it does not compile, so a caller passing a bare net name is
+   * never met with a syntax error.
+   */
+  async grepOutput(
+    pattern: string,
+    opts: { maxMatches?: number; contextLines?: number; ignoreCase?: boolean; commandNumber?: number } = {},
+  ): Promise<SessionGrepResult> {
+    const maxMatches = opts.maxMatches ?? 200;
+    const contextLines = Math.max(0, opts.contextLines ?? 0);
+    const ignoreCase = opts.ignoreCase ?? true;
+
+    const substringTest = (line: string): boolean => {
+      const needle = ignoreCase ? pattern.toLowerCase() : pattern;
+      return (ignoreCase ? line.toLowerCase() : line).includes(needle);
+    };
+
+    let test: (line: string) => boolean;
+    let patternKind: SessionGrepResult["patternKind"];
     try {
-      const regex = new RegExp(pattern, "i");
-      matching = lines.filter((line) => regex.test(line));
+      const regex = new RegExp(pattern, ignoreCase ? "i" : "");
+      test = (line: string): boolean => regex.test(line);
+      patternKind = "regex";
     } catch {
-      // Fallback to a case-insensitive substring search on invalid regex.
-      const needle = pattern.toLowerCase();
-      matching = lines.filter((line) => line.toLowerCase().includes(needle));
+      // An uncompilable pattern is a literal, not a user error.
+      test = substringTest;
+      patternKind = "substring";
     }
 
-    return matching.length > 0 ? matching.slice(-maxLines) : [];
+    const sources: SessionOutputRecord[] = this._outputHistory.filter(
+      (r) => opts.commandNumber === undefined || r.commandNumber === opts.commandNumber,
+    );
+    if (opts.commandNumber === undefined) {
+      // Output that has arrived but not yet been consumed by a command.
+      const pending = this.outputBuffer.toText(await this.outputBuffer.peekAll());
+      if (pending.length > 0) {
+        sources.push({
+          commandNumber: this.commandCount + 1,
+          command: "(unread buffer)",
+          timestamp: new Date().toISOString(),
+          output: pending,
+          truncated: false,
+        });
+      }
+    }
+
+    const search = (
+      predicate: (line: string) => boolean,
+    ): { matches: SessionGrepMatch[]; totalMatches: number; searchedLines: number } => {
+      const found: SessionGrepMatch[] = [];
+      let total = 0;
+      let scanned = 0;
+      for (const record of sources) {
+        const lines = record.output.split("\n");
+        scanned += lines.length;
+        for (let i = 0; i < lines.length; i += 1) {
+          if (!predicate(lines[i]!)) continue;
+          total += 1;
+          if (found.length >= maxMatches) continue;
+          found.push({
+            commandNumber: record.commandNumber,
+            command: record.command,
+            lineNumber: i + 1,
+            line: lines[i]!,
+            ...(contextLines > 0 && {
+              before: lines.slice(Math.max(0, i - contextLines), i),
+              after: lines.slice(i + 1, i + 1 + contextLines),
+            }),
+          });
+        }
+      }
+      return { matches: found, totalMatches: total, searchedLines: scanned };
+    };
+
+    let { matches, totalMatches, searchedLines } = search(test);
+
+    // A pasted instance or net name like `dpath.a_reg[0]` is *valid* regex that
+    // matches nothing, which is worse than a syntax error: the caller is told
+    // there are no matches when it is the pattern that is wrong. Retry such a
+    // pattern literally and say that is what happened.
+    if (totalMatches === 0 && patternKind === "regex" && /[[\](){}.*+?^$|\\]/.test(pattern)) {
+      const literal = search(substringTest);
+      if (literal.totalMatches > 0) {
+        ({ matches, totalMatches, searchedLines } = literal);
+        patternKind = "substring-fallback";
+      }
+    }
+
+    return {
+      matches,
+      totalMatches,
+      // Say plainly when matches were dropped, rather than returning a capped
+      // list that reads like the whole answer.
+      truncated: totalMatches > matches.length,
+      patternKind,
+      searchedCommands: sources.length,
+      searchedLines,
+      retainedChars: this._outputHistoryChars,
+      evictedCommands: this._outputHistoryEvicted,
+    };
+  }
+
+  /** Matching lines only. Retained for callers that just want the text. */
+  async filterOutput(pattern: string, maxLines = 1000): Promise<string[]> {
+    const result = await this.grepOutput(pattern, { maxMatches: maxLines });
+    return result.matches.map((m) => m.line);
   }
 }

--- a/typescript/src/interactive/session.ts
+++ b/typescript/src/interactive/session.ts
@@ -16,6 +16,7 @@ import {
   MAX_COMMAND_COMPLETION_WINDOW,
   MAX_COMMAND_HISTORY,
   PTY_LINE_TERMINATOR,
+  truncationNotice,
   UTILIZATION_PERCENTAGE_BASE,
 } from "../constants.js";
 import { CircularBuffer } from "./buffer.js";
@@ -304,13 +305,32 @@ export class InteractiveSession {
     ).toString(36)}`;
     const marker = SENTINEL_MARKER(nonce);
 
+    // Zero the buffer's discard counter so the result accounts for this
+    // command's loss only, not a previous command's.
+    await this.outputBuffer.takeDiscarded();
+
     await this.sendCommand(command);
     this._enqueueRaw(SENTINEL_COMMAND(nonce));
 
-    const { text, timedOut, died } = await this._readUntilMarker(marker, startTime, timeoutMs);
+    const { text, timedOut, died, discarded } = await this._readUntilMarker(
+      marker,
+      startTime,
+      timeoutMs,
+    );
+
+    // Output is lost in two places -- evicted from the buffer before we drained
+    // it, and sliced off the read accumulator once it passed the cap -- so both
+    // have to be summed for the total to be honest.
+    const bytesDiscarded = discarded + (await this.outputBuffer.takeDiscarded());
+    const totalBytes = text.length + bytesDiscarded;
 
     const executionTime = (Date.now() - startTime) / 1000;
-    const output = ANSIDecoder.cleanOpenroadOutput(this._stripSentinelLines(text));
+    const output = this._withTruncationNotice(
+      ANSIDecoder.cleanOpenroadOutput(this._stripSentinelLines(text)),
+      bytesDiscarded,
+      totalBytes,
+      text.length,
+    );
 
     await this._updatePerformanceMetrics();
     this._recordReadResult(output.length, executionTime);
@@ -323,6 +343,9 @@ export class InteractiveSession {
     } else if (died) {
       error = "SessionTerminated: process exited before the command completed";
     } else {
+      // Only the retained tail is inspected, so an error printed in the
+      // discarded head cannot be reported here. The truncation notice
+      // prepended to `output` is what warns the caller of that blind spot.
       error = this._detectErrors(output) ?? null;
     }
 
@@ -332,9 +355,26 @@ export class InteractiveSession {
       timestamp: new Date().toISOString(),
       executionTime,
       commandCount: this.commandCount,
-      bufferSize: this.outputBuffer.size,
+      bufferSize: this.outputBuffer.maxSize,
+      truncated: bytesDiscarded > 0,
+      bytesDiscarded,
+      totalBytes,
       error,
     };
+  }
+
+  /**
+   * Prepend the truncation banner when output was lost, and leave complete
+   * output byte-for-byte untouched.
+   */
+  private _withTruncationNotice(
+    output: string,
+    bytesDiscarded: number,
+    totalBytes: number,
+    retained: number,
+  ): string {
+    if (bytesDiscarded <= 0) return output;
+    return truncationNotice(bytesDiscarded, totalBytes, retained) + output;
   }
 
   /**
@@ -347,27 +387,31 @@ export class InteractiveSession {
     marker: string,
     startTime: number,
     timeoutMs: number,
-  ): Promise<{ text: string; timedOut: boolean; died: boolean }> {
+  ): Promise<{ text: string; timedOut: boolean; died: boolean; discarded: number }> {
     const cap = Math.max(this.outputBuffer.maxSize, 1);
     let text = "";
+    let discarded = 0;
 
     const absorb = (chunks: string[]): void => {
       if (chunks.length === 0) return;
       text += chunks.join("");
-      if (text.length > cap) text = text.slice(text.length - cap);
+      if (text.length > cap) {
+        discarded += text.length - cap;
+        text = text.slice(text.length - cap);
+      }
     };
 
     for (;;) {
       absorb(await this.outputBuffer.drainAll());
-      if (text.includes(marker)) return { text, timedOut: false, died: false };
+      if (text.includes(marker)) return { text, timedOut: false, died: false, discarded };
 
       if (!this.checkAlive()) {
         absorb(await this.outputBuffer.drainAll());
-        return { text, timedOut: false, died: !text.includes(marker) };
+        return { text, timedOut: false, died: !text.includes(marker), discarded };
       }
 
       const remaining = timeoutMs - (Date.now() - startTime);
-      if (remaining <= 0) return { text, timedOut: true, died: false };
+      if (remaining <= 0) return { text, timedOut: true, died: false, discarded };
 
       // Capped so process death (which appends nothing) is still noticed.
       await this.outputBuffer.waitForData(Math.min(remaining, SENTINEL_POLL_MS));
@@ -395,7 +439,15 @@ export class InteractiveSession {
     if (chunks.length === 0) {
       throw new SessionTerminatedError(`Session ${this.sessionId} is not active`, this.sessionId);
     }
-    const output = ANSIDecoder.cleanOpenroadOutput(this._stripSentinelLines(chunks.join("")));
+    const raw = chunks.join("");
+    const bytesDiscarded = await this.outputBuffer.takeDiscarded();
+    const totalBytes = raw.length + bytesDiscarded;
+    const output = this._withTruncationNotice(
+      ANSIDecoder.cleanOpenroadOutput(this._stripSentinelLines(raw)),
+      bytesDiscarded,
+      totalBytes,
+      raw.length,
+    );
     const executionTime = (Date.now() - startTime) / 1000;
     this._recordReadResult(output.length, executionTime);
     return {
@@ -404,7 +456,10 @@ export class InteractiveSession {
       timestamp: new Date().toISOString(),
       executionTime,
       commandCount: this.commandCount,
-      bufferSize: this.outputBuffer.size,
+      bufferSize: this.outputBuffer.maxSize,
+      truncated: bytesDiscarded > 0,
+      bytesDiscarded,
+      totalBytes,
       error: this._detectErrors(output) ?? null,
     };
   }
@@ -457,8 +512,15 @@ export class InteractiveSession {
     }
 
     const rawOutput = collected.join("");
+    const bytesDiscarded = await this.outputBuffer.takeDiscarded();
+    const totalBytes = rawOutput.length + bytesDiscarded;
     const executionTime = (Date.now() - startTime) / 1000;
-    const output = ANSIDecoder.cleanOpenroadOutput(rawOutput);
+    const output = this._withTruncationNotice(
+      ANSIDecoder.cleanOpenroadOutput(rawOutput),
+      bytesDiscarded,
+      totalBytes,
+      rawOutput.length,
+    );
 
     await this._updatePerformanceMetrics();
     this._recordReadResult(output.length, executionTime);
@@ -469,7 +531,10 @@ export class InteractiveSession {
       timestamp: new Date().toISOString(),
       executionTime,
       commandCount: this.commandCount,
-      bufferSize: this.outputBuffer.size,
+      bufferSize: this.outputBuffer.maxSize,
+      truncated: bytesDiscarded > 0,
+      bytesDiscarded,
+      totalBytes,
       error: this._detectErrors(output) ?? null,
     };
   }

--- a/typescript/src/server.ts
+++ b/typescript/src/server.ts
@@ -22,6 +22,8 @@ import {
 } from "./tools/interactive.js";
 import { ListReportImagesTool, ReadReportImageTool } from "./tools/report_images.js";
 import { ReadOrfsMetricsTool } from "./tools/orfs_metrics.js";
+import { RunOrfsStageTool, GetOrfsJobTool, CancelOrfsJobTool } from "./tools/flow_run.js";
+import { flowJobs } from "./core/flow_jobs.js";
 
 const logger = getLogger("server");
 
@@ -50,7 +52,7 @@ function text(value: string): { content: [{ type: "text"; text: string }] } {
 }
 
 /**
- * Build an McpServer with all 11 tools registered. Accepts an optional manager
+ * Build an McpServer with all 14 tools registered. Accepts an optional manager
  * so tests can inject an isolated/mocked one; defaults to the module singleton.
  *
  * Tool names, descriptions, input params, and annotations mirror the Python
@@ -70,6 +72,9 @@ export function createMcpServer(manager: OpenROADManager = defaultManager): McpS
   const listReportImagesTool = new ListReportImagesTool(manager);
   const readReportImageTool = new ReadReportImageTool(manager);
   const readOrfsMetricsTool = new ReadOrfsMetricsTool(manager);
+  const runOrfsStageTool = new RunOrfsStageTool(manager);
+  const getOrfsJobTool = new GetOrfsJobTool(manager);
+  const cancelOrfsJobTool = new CancelOrfsJobTool(manager);
 
   mcp.registerTool(
     "interactive_openroad_query",
@@ -311,6 +316,91 @@ export function createMcpServer(manager: OpenROADManager = defaultManager): McpS
       ),
   );
 
+  mcp.registerTool(
+    "run_orfs_stage",
+    {
+      description:
+        "Run an ORFS flow stage (synth, floorplan, place, cts, grt, route, finish, or a clean_* " +
+        "target) via make, streaming output to a file rather than the session buffer. Returns a " +
+        "job_id immediately so a multi-hour route does not block the call; pass wait_seconds to " +
+        "get the finished result inline when the stage is short. `overrides` become make " +
+        "command-line assignments (e.g. {\"CTS_CLUSTER_SIZE\": \"20\"}), which take precedence " +
+        "over both the environment and the Makefile. Poll with get_orfs_job for live progress, " +
+        "and the parsed stage metrics and gate verdicts once it finishes. Set dry_run to see what " +
+        "make would do without running it.",
+      inputSchema: {
+        design: z.string(),
+        stage: z.string(),
+        overrides: z.record(z.string(), z.string()).optional(),
+        platform: z.string().optional(),
+        variant: z.string().optional(),
+        wait_seconds: z.number().int().positive().optional(),
+        jobs: z.number().int().positive().optional(),
+        timeout_seconds: z.number().int().positive().optional(),
+        dry_run: z.boolean().optional(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async (args) =>
+      text(
+        await runOrfsStageTool.execute(
+          args.design,
+          args.stage,
+          args.overrides,
+          args.platform,
+          args.variant,
+          args.wait_seconds,
+          args.jobs,
+          args.timeout_seconds,
+          args.dry_run,
+        ),
+      ),
+  );
+
+  mcp.registerTool(
+    "get_orfs_job",
+    {
+      description:
+        "Poll a flow run started by run_orfs_stage: status, elapsed time, the ORFS stage currently " +
+        "executing, detailed-route iteration and live DRC violation count, CPU and memory, and the " +
+        "tail of the run log. Once the run succeeds it also carries the parsed stage metrics and " +
+        "rules-base gate verdicts. Omit job_id to list every run.",
+      inputSchema: {
+        job_id: z.string().optional(),
+        recent_lines: z.number().int().positive().optional(),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (args) => text(await getOrfsJobTool.execute(args.job_id, args.recent_lines)),
+  );
+
+  mcp.registerTool(
+    "cancel_orfs_job",
+    {
+      description:
+        "Terminate a running flow job and every process it spawned, so no orphaned openroad " +
+        "process is left behind.",
+      inputSchema: { job_id: z.string() },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (args) => text(await cancelOrfsJobTool.execute(args.job_id)),
+  );
+
   return mcp;
 }
 
@@ -389,6 +479,9 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse): Pro
  */
 export async function runServer(config: CLIConfig): Promise<void> {
   cleanupManager.registerAsyncCleanupHandler(shutdownOpenroad);
+  // A flow run outlives the server otherwise: make and its openroad children
+  // are in their own process group and would keep going after we exit.
+  cleanupManager.registerAsyncCleanupHandler(() => flowJobs.shutdown());
   cleanupManager.setupSignalHandlers();
 
   try {

--- a/typescript/src/server.ts
+++ b/typescript/src/server.ts
@@ -34,6 +34,16 @@ const VERSION = (
   }
 ).version;
 
+/**
+ * Appended to both shell tool descriptions. Output that exceeds the session
+ * buffer loses its head, and a result that begins mid-line otherwise reads as
+ * a complete answer -- so the caller has to be told these fields exist.
+ */
+const TRUNCATION_FIELD_DOC =
+  "Results carry `truncated`, `bytes_discarded` and `total_bytes`: when `truncated` is true the " +
+  "output lost its beginning to the session buffer and is a PARTIAL answer, so do not treat it as " +
+  "complete — narrow the command and re-run.";
+
 function text(value: string): { content: [{ type: "text"; text: string }] } {
   return { content: [{ type: "text" as const, text: value }] };
 }
@@ -65,7 +75,8 @@ export function createMcpServer(manager: OpenROADManager = defaultManager): McpS
       description:
         "Execute a read-only OpenROAD command (report_*, get_*, check_*, sta, help, etc.). " +
         "Use this for querying design state, generating reports, and inspecting timing. " +
-        "Commands that modify design state are blocked — use interactive_openroad_exec instead.",
+        "Commands that modify design state are blocked — use interactive_openroad_exec instead. " +
+        TRUNCATION_FIELD_DOC,
       inputSchema: {
         command: z.string(),
         session_id: z.string().optional(),
@@ -89,7 +100,8 @@ export function createMcpServer(manager: OpenROADManager = defaultManager): McpS
         "Use this for loading designs, running placement/routing, applying constraints, and writing " +
         "output files. Only the BLOCKED_COMMANDS list (quit, socket, load, glob, etc.) is rejected; " +
         "read-only commands such as report_* are also accepted here. Use interactive_openroad_query " +
-        "instead for queries to keep state changes visible and auditable.",
+        "instead for queries to keep state changes visible and auditable. " +
+        TRUNCATION_FIELD_DOC,
       inputSchema: {
         command: z.string(),
         session_id: z.string().optional(),

--- a/typescript/src/server.ts
+++ b/typescript/src/server.ts
@@ -19,6 +19,7 @@ import {
   SessionHistoryTool,
   SessionMetricsTool,
   TerminateSessionTool,
+  GrepSessionOutputTool,
 } from "./tools/interactive.js";
 import { ListReportImagesTool, ReadReportImageTool } from "./tools/report_images.js";
 import { ReadOrfsMetricsTool } from "./tools/orfs_metrics.js";
@@ -52,7 +53,7 @@ function text(value: string): { content: [{ type: "text"; text: string }] } {
 }
 
 /**
- * Build an McpServer with all 14 tools registered. Accepts an optional manager
+ * Build an McpServer with all 15 tools registered. Accepts an optional manager
  * so tests can inject an isolated/mocked one; defaults to the module singleton.
  *
  * Tool names, descriptions, input params, and annotations mirror the Python
@@ -71,6 +72,7 @@ export function createMcpServer(manager: OpenROADManager = defaultManager): McpS
   const sessionMetricsTool = new SessionMetricsTool(manager);
   const listReportImagesTool = new ListReportImagesTool(manager);
   const readReportImageTool = new ReadReportImageTool(manager);
+  const grepSessionOutputTool = new GrepSessionOutputTool(manager);
   const readOrfsMetricsTool = new ReadOrfsMetricsTool(manager);
   const runOrfsStageTool = new RunOrfsStageTool(manager);
   const getOrfsJobTool = new GetOrfsJobTool(manager);
@@ -278,6 +280,44 @@ export function createMcpServer(manager: OpenROADManager = defaultManager): McpS
       );
       return { content: blocks, ...(isError && { isError: true }) };
     },
+  );
+
+  mcp.registerTool(
+    "grep_session_output",
+    {
+      description:
+        "Search the output of commands already run in a session, without re-running them or " +
+        "re-sending a large result. `pattern` is a regular expression, falling back to a substring " +
+        "search if it does not compile. Use `context_lines` to see surrounding lines and " +
+        "`command_number` to search one command's output. Only recent output is retained " +
+        "(OPENROAD_OUTPUT_HISTORY_CHARS, default 256 KB); the result reports how much was searched " +
+        "and whether older output has been evicted.",
+      inputSchema: {
+        session_id: z.string(),
+        pattern: z.string(),
+        max_matches: z.number().int().positive().optional(),
+        context_lines: z.number().int().nonnegative().optional(),
+        ignore_case: z.boolean().optional(),
+        command_number: z.number().int().positive().optional(),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (args) =>
+      text(
+        await grepSessionOutputTool.execute(
+          args.session_id,
+          args.pattern,
+          args.max_matches,
+          args.context_lines,
+          args.ignore_case,
+          args.command_number,
+        ),
+      ),
   );
 
   mcp.registerTool(

--- a/typescript/src/server.ts
+++ b/typescript/src/server.ts
@@ -243,12 +243,16 @@ export function createMcpServer(manager: OpenROADManager = defaultManager): McpS
   mcp.registerTool(
     "read_report_image",
     {
-      description: "Read a report image and return base64-encoded data with metadata.",
+      description:
+        "Read a report image (congestion, IR-drop, placement, clock tree) and return it as a " +
+        "viewable image alongside its metadata. Optionally pass max_size_kb to override the " +
+        "configured base64 budget for this call; larger budgets keep more detail in heatmaps.",
       inputSchema: {
         platform: z.string(),
         design: z.string(),
         run_slug: z.string(),
         image_name: z.string(),
+        max_size_kb: z.number().int().positive().optional(),
       },
       annotations: {
         readOnlyHint: true,
@@ -257,15 +261,16 @@ export function createMcpServer(manager: OpenROADManager = defaultManager): McpS
         openWorldHint: false,
       },
     },
-    async (args) =>
-      text(
-        await readReportImageTool.execute(
-          args.platform,
-          args.design,
-          args.run_slug,
-          args.image_name,
-        ),
-      ),
+    async (args) => {
+      const { blocks, isError } = await readReportImageTool.executeContent(
+        args.platform,
+        args.design,
+        args.run_slug,
+        args.image_name,
+        args.max_size_kb,
+      );
+      return { content: blocks, ...(isError && { isError: true }) };
+    },
   );
 
   return mcp;

--- a/typescript/src/server.ts
+++ b/typescript/src/server.ts
@@ -21,6 +21,7 @@ import {
   TerminateSessionTool,
 } from "./tools/interactive.js";
 import { ListReportImagesTool, ReadReportImageTool } from "./tools/report_images.js";
+import { ReadOrfsMetricsTool } from "./tools/orfs_metrics.js";
 
 const logger = getLogger("server");
 
@@ -49,7 +50,7 @@ function text(value: string): { content: [{ type: "text"; text: string }] } {
 }
 
 /**
- * Build an McpServer with all 10 tools registered. Accepts an optional manager
+ * Build an McpServer with all 11 tools registered. Accepts an optional manager
  * so tests can inject an isolated/mocked one; defaults to the module singleton.
  *
  * Tool names, descriptions, input params, and annotations mirror the Python
@@ -68,6 +69,7 @@ export function createMcpServer(manager: OpenROADManager = defaultManager): McpS
   const sessionMetricsTool = new SessionMetricsTool(manager);
   const listReportImagesTool = new ListReportImagesTool(manager);
   const readReportImageTool = new ReadReportImageTool(manager);
+  const readOrfsMetricsTool = new ReadOrfsMetricsTool(manager);
 
   mcp.registerTool(
     "interactive_openroad_query",
@@ -271,6 +273,42 @@ export function createMcpServer(manager: OpenROADManager = defaultManager): McpS
       );
       return { content: blocks, ...(isError && { isError: true }) };
     },
+  );
+
+  mcp.registerTool(
+    "read_orfs_metrics",
+    {
+      description:
+        "Read an ORFS design's per-stage metrics, its rules-base.json gate thresholds evaluated " +
+        "against those metrics, and the tagged errors/warnings from each stage log. Prefer this " +
+        "over shelling out to find/cat/jq/grep in the flow tree. `stage` accepts a step name " +
+        "(cts, place, route, floorplan, synth, finish), an ORFS metric namespace " +
+        "(globalroute, detailedroute, placeopt, detailedplace), an exact file stem (4_1_cts), or " +
+        "`all` (the default). `platform` is inferred from `design` when unambiguous. Note that " +
+        "ORFS records some metrics once per sub-run: any key listed in `repeated_metrics` has an " +
+        "array of values in file order rather than a scalar.",
+      inputSchema: {
+        design: z.string(),
+        stage: z.string().optional(),
+        platform: z.string().optional(),
+        variant: z.string().optional(),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (args) =>
+      text(
+        await readOrfsMetricsTool.execute(
+          args.design,
+          args.stage,
+          args.platform,
+          args.variant,
+        ),
+      ),
   );
 
   return mcp;

--- a/typescript/src/tools/base.ts
+++ b/typescript/src/tools/base.ts
@@ -1,11 +1,18 @@
 import type { OpenROADManager } from "../core/manager.js";
 
 function camelToSnakeKey(key: string): string {
-  // A key with no lowercase letters is not camelCase -- it is a SCREAMING_SNAKE
-  // identifier that arrived as data, such as an ORFS make variable
-  // (CTS_CLUSTER_SIZE). Converting it produces _c_t_s__c_l_u_s_t_e_r__s_i_z_e
-  // and destroys a name the caller has to be able to read back.
-  if (!/[a-z]/.test(key)) return key;
+  // camelCase never contains an underscore or a colon, so a key that does is
+  // not a field name -- it is data that happens to be an object key, and
+  // rewriting it destroys a name the caller has to be able to read back.
+  //
+  // Two real cases this protects, both seen in live runs: an ORFS make
+  // variable (CTS_CLUSTER_SIZE, which became _c_t_s__c_l_u_s_t_e_r__s_i_z_e)
+  // and an ORFS metric key carrying a site name
+  // (cts__design__rows:FreePDK45_38x28_10R_NP_162NW_34o, which became
+  // ...rows:_free_p_d_k45_38x28_10_r__n_p_162_n_w_34_o). The second is why
+  // "has no lowercase letters" was not a sufficient test: the key is mostly
+  // lowercase and only the payload after the colon is mixed case.
+  if (key.includes("_") || key.includes(":")) return key;
   return key.replace(/[A-Z]/g, (ch) => `_${ch.toLowerCase()}`);
 }
 

--- a/typescript/src/tools/base.ts
+++ b/typescript/src/tools/base.ts
@@ -12,7 +12,13 @@ function camelToSnakeKey(key: string): string {
   // ...rows:_free_p_d_k45_38x28_10_r__n_p_162_n_w_34_o). The second is why
   // "has no lowercase letters" was not a sufficient test: the key is mostly
   // lowercase and only the payload after the colon is mixed case.
-  if (key.includes("_") || key.includes(":")) return key;
+  //
+  // Neither test covers a single all-uppercase token -- CORNER, JOBS, GDS are
+  // all valid ORFS override names and none contains an underscore or a colon.
+  // camelCase always carries at least one lowercase letter, so "no lowercase
+  // at all" is a safe third bail-out. It is not sufficient on its own, which
+  // is what the site-name case above shows, but it closes the single-token gap.
+  if (key.includes("_") || key.includes(":") || !/[a-z]/.test(key)) return key;
   return key.replace(/[A-Z]/g, (ch) => `_${ch.toLowerCase()}`);
 }
 

--- a/typescript/src/tools/base.ts
+++ b/typescript/src/tools/base.ts
@@ -1,13 +1,18 @@
 import type { OpenROADManager } from "../core/manager.js";
 
 function camelToSnakeKey(key: string): string {
+  // A key with no lowercase letters is not camelCase -- it is a SCREAMING_SNAKE
+  // identifier that arrived as data, such as an ORFS make variable
+  // (CTS_CLUSTER_SIZE). Converting it produces _c_t_s__c_l_u_s_t_e_r__s_i_z_e
+  // and destroys a name the caller has to be able to read back.
+  if (!/[a-z]/.test(key)) return key;
   return key.replace(/[A-Z]/g, (ch) => `_${ch.toLowerCase()}`);
 }
 
 /**
  * Recursively convert camelCase object keys to snake_case. Idempotent on
- * already-snake_case keys, so opaque snake_case payloads pass through
- * unchanged.
+ * already-snake_case keys, and leaves SCREAMING_SNAKE keys alone, so opaque
+ * payloads keyed by caller-supplied names pass through unchanged.
  */
 export function toSnakeCase(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(toSnakeCase);

--- a/typescript/src/tools/flow_run.ts
+++ b/typescript/src/tools/flow_run.ts
@@ -1,0 +1,308 @@
+import fs from "node:fs";
+import path from "node:path";
+import { getSettings } from "../config/settings.js";
+import type { OpenROADManager } from "../core/manager.js";
+import { flowJobs, FlowJobLimitError, FlowJobNotFoundError } from "../core/flow_jobs.js";
+import type { FlowJob, FlowJobRegistry } from "../core/flow_jobs.js";
+import { ValidationError } from "../exceptions.js";
+import { DEFAULT_RECENT_LINES } from "../flow/run_progress.js";
+import { validatePathSegment } from "../utils/path_security.js";
+import { BaseTool } from "./base.js";
+import {
+  evaluateGates,
+  parseMetricsPreservingDuplicates,
+  resolvePlatform,
+  resolveStages,
+} from "./orfs_metrics.js";
+import type { GateRule } from "./orfs_metrics.js";
+
+/**
+ * Make targets this server will run.
+ *
+ * OPENROAD_ALLOWED_COMMANDS gates the `openroad` binary only and does not cover
+ * this path, so the flow runner carries its own policy. An allowlist also stops
+ * a target doubling as a make flag: `-f/tmp/evil.mk` would otherwise be handed
+ * to make as an argument, not a goal.
+ */
+export const ALLOWED_TARGETS = new Set([
+  "synth", "floorplan", "place", "cts", "grt", "route", "finish", "all", "metadata",
+  "clean_synth", "clean_floorplan", "clean_place", "clean_cts", "clean_route",
+  "clean_finish", "clean_metadata", "clean_all",
+]);
+
+/** Make variables that would redirect execution, whatever their value. */
+const DENIED_OVERRIDE_KEYS = new Set([
+  "SHELL", "MAKESHELL", ".SHELLFLAGS", "MAKE", "MAKEFLAGS", "MAKEFILES",
+  "PATH", "LD_PRELOAD", "LD_LIBRARY_PATH", "DYLD_INSERT_LIBRARIES",
+]);
+
+const OVERRIDE_KEY = /^[A-Z_][A-Z0-9_]*$/;
+
+/** Reject a target that is not a known ORFS goal. */
+export function validateTarget(stage: string): string {
+  const target = stage.trim();
+  if (!ALLOWED_TARGETS.has(target)) {
+    throw new ValidationError(
+      `Stage '${stage}' is not a runnable ORFS target. ` +
+        `Allowed: ${[...ALLOWED_TARGETS].sort().join(", ")}`,
+    );
+  }
+  return target;
+}
+
+/**
+ * Reject override keys and values that could redirect what make executes.
+ *
+ * `shell: false` stops a shell reinterpreting a value, but make itself expands
+ * `$(...)` inside variable values and will use an overridden SHELL to run every
+ * recipe -- so neither is safe to accept.
+ */
+export function validateOverrides(
+  overrides: Record<string, string> | undefined | null,
+): Record<string, string> {
+  const clean: Record<string, string> = {};
+  for (const [key, rawValue] of Object.entries(overrides ?? {})) {
+    if (!OVERRIDE_KEY.test(key)) {
+      throw new ValidationError(
+        `Override key '${key}' is not a valid make variable name (expected ^[A-Z_][A-Z0-9_]*$)`,
+      );
+    }
+    if (DENIED_OVERRIDE_KEYS.has(key)) {
+      throw new ValidationError(
+        `Override key '${key}' is not allowed: it controls how make executes its recipes.`,
+      );
+    }
+    const value = String(rawValue);
+    if (/[\r\n\0]/.test(value)) {
+      throw new ValidationError(`Override '${key}' cannot contain newlines or null bytes`);
+    }
+    if (value.includes("$(") || value.includes("${") || value.includes("`")) {
+      throw new ValidationError(
+        `Override '${key}' cannot contain '$(', '\${' or backticks: make expands these when it reads the value.`,
+      );
+    }
+    clean[key] = value;
+  }
+  return clean;
+}
+
+/** Metrics and gate verdicts for a finished run, reusing the read_orfs_metrics machinery. */
+function collectResults(job: FlowJob): {
+  stages: Array<{ stage: string; metrics: Record<string, unknown>; repeatedMetrics: string[] }>;
+  gates: unknown[];
+  gateSummary: Record<string, number> | null;
+} {
+  const settings = getSettings();
+  let stems: string[] = [];
+  try {
+    stems = fs
+      .readdirSync(job.logsDir)
+      .filter((e) => e.endsWith(".json"))
+      .map((e) => e.slice(0, -".json".length))
+      .sort();
+  } catch {
+    return { stages: [], gates: [], gateSummary: null };
+  }
+
+  const selected = resolveStages(stems, job.spec.target);
+  const stages = selected.flatMap((stem) => {
+    try {
+      const parsed = parseMetricsPreservingDuplicates(
+        fs.readFileSync(path.join(job.logsDir, `${stem}.json`), "utf8"),
+      );
+      return [{ stage: stem, metrics: parsed.metrics, repeatedMetrics: parsed.repeatedMetrics }];
+    } catch {
+      return [];
+    }
+  });
+
+  let rules: Record<string, GateRule> = {};
+  try {
+    rules = JSON.parse(
+      fs.readFileSync(
+        path.join(settings.flowPath, "designs", job.spec.platform, job.spec.design, "rules-base.json"),
+        "utf8",
+      ),
+    ) as Record<string, GateRule>;
+  } catch {
+    rules = {};
+  }
+
+  const { gates } = evaluateGates(stages, rules);
+  const failing = gates.filter((g) => g.status === "fail");
+  return {
+    stages,
+    gates,
+    gateSummary: {
+      total: gates.length,
+      pass: gates.filter((g) => g.status === "pass").length,
+      fail: failing.length,
+      failingErrors: failing.filter((g) => g.level === "error").length,
+    },
+  };
+}
+
+/** Shared serialisation for a job, with progress and (when finished) results. */
+function describeJob(
+  registry: FlowJobRegistry,
+  jobId: string,
+  recentLines: number,
+): Record<string, unknown> {
+  const view = registry.inspect(jobId, recentLines);
+  const { job } = view;
+  const finished = job.status !== "running";
+  const results = finished && job.status === "succeeded" ? collectResults(job) : null;
+
+  return {
+    jobId: job.jobId,
+    status: job.status,
+    platform: job.spec.platform,
+    design: job.spec.design,
+    variant: job.spec.variant,
+    stage: job.spec.target,
+    overrides: job.spec.overrides,
+    dryRun: job.spec.dryRun === true,
+    command: job.argv.join(" "),
+    pid: job.pid,
+    startedAt: job.startedAt,
+    finishedAt: job.finishedAt,
+    elapsedSeconds: view.elapsedSeconds,
+    exitCode: job.exitCode,
+    signal: job.signal,
+    logPath: job.logPath,
+    logBytes: view.logBytes,
+    logTruncated: view.logTruncated,
+    progress: view.progress,
+    recentLines: view.recentLines,
+    stages: results?.stages ?? [],
+    gates: results?.gates ?? [],
+    gateSummary: results?.gateSummary ?? null,
+    error: job.error,
+  };
+}
+
+function failure(error: string, message: string): string {
+  return JSON.stringify({ job_id: null, status: null, message, error });
+}
+
+/** Start an ORFS flow stage as a tracked background run. */
+export class RunOrfsStageTool extends BaseTool {
+  constructor(manager: OpenROADManager, private readonly registry: FlowJobRegistry = flowJobs) {
+    super(manager);
+  }
+
+  async execute(
+    design: string,
+    stage: string,
+    overrides?: Record<string, string> | null,
+    platform?: string | null,
+    variant = "base",
+    waitSeconds?: number | null,
+    jobs?: number | null,
+    timeoutSeconds?: number | null,
+    dryRun?: boolean | null,
+    recentLines = DEFAULT_RECENT_LINES,
+  ): Promise<string> {
+    let resolvedPlatform: string;
+    let target: string;
+    let cleanOverrides: Record<string, string>;
+    try {
+      validatePathSegment(design, "design");
+      validatePathSegment(variant, "variant");
+      resolvedPlatform = resolvePlatform(design, platform);
+      target = validateTarget(stage);
+      cleanOverrides = validateOverrides(overrides);
+    } catch (e) {
+      if (e instanceof ValidationError) return failure(e.constructor.name, e.message);
+      return failure("UnexpectedError", (e as Error).message ?? String(e));
+    }
+
+    const flowPath = getSettings().flowPath;
+    if (!fs.existsSync(flowPath)) {
+      return failure("FlowPathNotFound", `ORFS flow directory not found at ${flowPath}`);
+    }
+
+    let job: FlowJob;
+    try {
+      job = this.registry.start(
+        {
+          platform: resolvedPlatform,
+          design,
+          variant,
+          target,
+          overrides: cleanOverrides,
+          ...(jobs != null && { jobs }),
+          ...(dryRun != null && { dryRun }),
+          ...(timeoutSeconds != null && { timeoutSeconds }),
+        },
+        flowPath,
+      );
+    } catch (e) {
+      if (e instanceof FlowJobLimitError) return failure("FlowJobLimit", e.message);
+      return failure("UnexpectedError", (e as Error).message ?? String(e));
+    }
+
+    if (waitSeconds != null && waitSeconds > 0) {
+      await this.registry.waitFor(job.jobId, waitSeconds * 1000);
+    }
+
+    return this.formatResult(describeJob(this.registry, job.jobId, recentLines));
+  }
+}
+
+/** Poll one flow run, or list them all. */
+export class GetOrfsJobTool extends BaseTool {
+  constructor(manager: OpenROADManager, private readonly registry: FlowJobRegistry = flowJobs) {
+    super(manager);
+  }
+
+  async execute(jobId?: string | null, recentLines = DEFAULT_RECENT_LINES): Promise<string> {
+    if (jobId == null || jobId === "") {
+      return this.formatResult({
+        jobs: this.registry.list().map((j) => ({
+          jobId: j.jobId,
+          status: j.status,
+          design: j.spec.design,
+          stage: j.spec.target,
+          variant: j.spec.variant,
+          startedAt: j.startedAt,
+          finishedAt: j.finishedAt,
+          exitCode: j.exitCode,
+        })),
+        totalCount: this.registry.size,
+        activeCount: this.registry.activeCount(),
+        error: null,
+      });
+    }
+
+    try {
+      return this.formatResult(describeJob(this.registry, jobId, recentLines));
+    } catch (e) {
+      if (e instanceof FlowJobNotFoundError) return failure("FlowJobNotFound", e.message);
+      return failure("UnexpectedError", (e as Error).message ?? String(e));
+    }
+  }
+}
+
+/** Terminate a flow run and every process it spawned. */
+export class CancelOrfsJobTool extends BaseTool {
+  constructor(manager: OpenROADManager, private readonly registry: FlowJobRegistry = flowJobs) {
+    super(manager);
+  }
+
+  async execute(jobId: string): Promise<string> {
+    try {
+      const job = this.registry.cancel(jobId);
+      return this.formatResult({
+        jobId: job.jobId,
+        status: job.status,
+        cancelled: job.status === "cancelled",
+        exitCode: job.exitCode,
+        error: null,
+      });
+    } catch (e) {
+      if (e instanceof FlowJobNotFoundError) return failure("FlowJobNotFound", e.message);
+      return failure("UnexpectedError", (e as Error).message ?? String(e));
+    }
+  }
+}

--- a/typescript/src/tools/flow_run.ts
+++ b/typescript/src/tools/flow_run.ts
@@ -104,12 +104,17 @@ function collectResults(job: FlowJob): {
     return { stages: [], gates: [], gateSummary: null };
   }
 
+  // Only count metrics this run actually produced. A `make` that finds its
+  // target up to date exits in milliseconds having written nothing, and the
+  // stage files from a previous run are still on disk -- reporting those as
+  // this job's results turns "nothing happened" into a green QoR report.
+  const startedMs = Date.parse(job.startedAt);
   const selected = resolveStages(stems, job.spec.target);
   const stages = selected.flatMap((stem) => {
+    const metricsPath = path.join(job.logsDir, `${stem}.json`);
     try {
-      const parsed = parseMetricsPreservingDuplicates(
-        fs.readFileSync(path.join(job.logsDir, `${stem}.json`), "utf8"),
-      );
+      if (fs.statSync(metricsPath).mtimeMs < startedMs) return [];
+      const parsed = parseMetricsPreservingDuplicates(fs.readFileSync(metricsPath, "utf8"));
       return [{ stage: stem, metrics: parsed.metrics, repeatedMetrics: parsed.repeatedMetrics }];
     } catch {
       return [];

--- a/typescript/src/tools/index.ts
+++ b/typescript/src/tools/index.ts
@@ -20,3 +20,4 @@ export {
   compareGate,
   extractLogDiagnostics,
 } from "./orfs_metrics.js";
+export { RunOrfsStageTool, GetOrfsJobTool, CancelOrfsJobTool, validateTarget, validateOverrides, ALLOWED_TARGETS } from "./flow_run.js";

--- a/typescript/src/tools/index.ts
+++ b/typescript/src/tools/index.ts
@@ -11,3 +11,12 @@ export {
   TerminateSessionTool,
 } from "./interactive.js";
 export { ListReportImagesTool, ReadReportImageTool, classifyImageType, validatePlatformDesign } from "./report_images.js";
+export {
+  ReadOrfsMetricsTool,
+  parseMetricsPreservingDuplicates,
+  resolvePlatform,
+  resolveStages,
+  evaluateGates,
+  compareGate,
+  extractLogDiagnostics,
+} from "./orfs_metrics.js";

--- a/typescript/src/tools/index.ts
+++ b/typescript/src/tools/index.ts
@@ -9,6 +9,7 @@ export {
   SessionHistoryTool,
   SessionMetricsTool,
   TerminateSessionTool,
+  GrepSessionOutputTool,
 } from "./interactive.js";
 export { ListReportImagesTool, ReadReportImageTool, classifyImageType, validatePlatformDesign } from "./report_images.js";
 export {

--- a/typescript/src/tools/interactive.ts
+++ b/typescript/src/tools/interactive.ts
@@ -42,6 +42,9 @@ function blankExecResult(
     executionTime: 0.0,
     commandCount: 0,
     bufferSize: 0,
+    truncated: false,
+    bytesDiscarded: 0,
+    totalBytes: 0,
     error,
   };
 }
@@ -57,6 +60,9 @@ function sessionNotFoundExecResult(
     executionTime: 0.0,
     commandCount: 0,
     bufferSize: 0,
+    truncated: false,
+    bytesDiscarded: 0,
+    totalBytes: 0,
     error: String(error),
   };
 }
@@ -73,6 +79,9 @@ function blockedError(
     executionTime: 0.0,
     commandCount: 0,
     bufferSize: 0,
+    truncated: false,
+    bytesDiscarded: 0,
+    totalBytes: 0,
     error: `CommandBlocked: '${blockedVerb}'`,
   };
   const message = `Command blocked: '${blockedVerb}' is not on the OpenROAD allowlist.\nFull command: ${pyRepr(command)}`;

--- a/typescript/src/tools/interactive.ts
+++ b/typescript/src/tools/interactive.ts
@@ -5,6 +5,7 @@ import {
 } from "../config/command_whitelist.js";
 import type { OpenROADManager } from "../core/manager.js";
 import {
+  SessionGrepOutputResult,
   InteractiveSessionListResult,
   SessionHistoryResult,
   SessionInspectionResult,
@@ -433,3 +434,69 @@ export class SessionMetricsTool extends BaseTool {
 }
 
 export const InteractiveShellTool = QueryShellTool;
+
+/**
+ * Search a session's recent command output.
+ *
+ * The alternative is re-sending a large result just to find a few lines in it:
+ * a single `report_checks` came back at 131 KB in the capability study, and the
+ * agent had to work through the whole thing to rank a handful of paths.
+ */
+export class GrepSessionOutputTool extends BaseTool {
+  constructor(manager: OpenROADManager) {
+    super(manager);
+  }
+
+  async execute(
+    sessionId: string,
+    pattern: string,
+    maxMatches?: number | null,
+    contextLines?: number | null,
+    ignoreCase?: boolean | null,
+    commandNumber?: number | null,
+  ): Promise<string> {
+    try {
+      const result = await this.manager.grepSessionOutput(sessionId, pattern, {
+        ...(maxMatches != null && { maxMatches }),
+        ...(contextLines != null && { contextLines }),
+        ...(ignoreCase != null && { ignoreCase }),
+        ...(commandNumber != null && { commandNumber }),
+      });
+
+      const message =
+        result.searchedCommands === 0
+          ? "No command output is retained for this session yet. Run a command first."
+          : result.truncated
+            ? `Showing ${result.matches.length} of ${result.totalMatches} matches; raise max_matches or narrow the pattern.`
+            : null;
+
+      return this.formatResult(
+        SessionGrepOutputResult.parse({
+          sessionId,
+          pattern,
+          ...result,
+          message,
+        }) as unknown as Record<string, unknown>,
+      );
+    } catch (e) {
+      if (e instanceof SessionNotFoundError) {
+        return this.formatResult(
+          SessionGrepOutputResult.parse({
+            sessionId,
+            pattern,
+            error: "SessionNotFound",
+            message: (e as Error).message,
+          }) as unknown as Record<string, unknown>,
+        );
+      }
+      return this.formatResult(
+        SessionGrepOutputResult.parse({
+          sessionId,
+          pattern,
+          error: "UnexpectedError",
+          message: (e as Error).message ?? String(e),
+        }) as unknown as Record<string, unknown>,
+      );
+    }
+  }
+}

--- a/typescript/src/tools/interactive.ts
+++ b/typescript/src/tools/interactive.ts
@@ -1,5 +1,6 @@
 import { getSettings } from "../config/settings.js";
 import {
+  BLOCK_GUIDANCE,
   isExecCommand,
   isQueryCommand,
 } from "../config/command_whitelist.js";
@@ -85,7 +86,11 @@ function blockedError(
     totalBytes: 0,
     error: `CommandBlocked: '${blockedVerb}'`,
   };
-  const message = `Command blocked: '${blockedVerb}' is not on the OpenROAD allowlist.\nFull command: ${pyRepr(command)}`;
+  const guidance = BLOCK_GUIDANCE[blockedVerb];
+  const message =
+    `Command blocked: '${blockedVerb}' is not on the OpenROAD allowlist.\n` +
+    `Full command: ${pyRepr(command)}` +
+    (guidance === undefined ? "" : `\n${guidance}`);
   return JSON.stringify(toSnakeCase({ ...base, message }));
 }
 

--- a/typescript/src/tools/orfs_metrics.ts
+++ b/typescript/src/tools/orfs_metrics.ts
@@ -1,0 +1,568 @@
+import fs from "node:fs";
+import path from "node:path";
+import { getSettings } from "../config/settings.js";
+import type { OpenROADManager } from "../core/manager.js";
+import { OrfsMetricsResult } from "../core/models.js";
+import type { OrfsStageMetrics } from "../core/models.js";
+import { ValidationError } from "../exceptions.js";
+import {
+  validatePathSegment,
+  validateSafePathContainment,
+} from "../utils/path_security.js";
+import { BaseTool } from "./base.js";
+
+/**
+ * Stage aliases, tried before a plain substring match.
+ *
+ * ORFS rule files key metrics by namespace (`globalroute__*`) while the files
+ * on disk are numbered by step (`5_1_grt.json`), so a caller who has read
+ * rules-base.json has no way to guess the filename. These map both the
+ * namespaces and the everyday stage names onto stem fragments.
+ */
+const NAMESPACE_ALIASES: Record<string, string> = {
+  placeopt: "place_resized",
+  detailedplace: "place_dp",
+  globalplace: "place_gp",
+  globalroute: "grt",
+  detailedroute: "route",
+  finish: "report",
+};
+
+/** Everyday stage names, mapped to the numeric prefix ORFS gives that group. */
+const GROUP_ALIASES: Record<string, string> = {
+  synth: "1_",
+  synthesis: "1_",
+  floorplan: "2_",
+  place: "3_",
+  placement: "3_",
+  cts: "4_",
+  route: "5_",
+  routing: "5_",
+  finish: "6_",
+};
+
+/** Per-stage cap on returned log lines, so one noisy stage cannot swamp a result. */
+const MAX_LOG_LINES = 50;
+
+/** ORFS tags its own diagnostics; free-text lines mentioning "error" are noise. */
+const ERROR_LINE = /^\s*\[ERROR\s+[^\]]*\]/;
+const WARNING_LINE = /^\s*\[WARNING\s+[^\]]*\]/;
+
+/** A metric value as ORFS writes it, or an array when the file repeated the key. */
+export type MetricValue = unknown;
+
+export interface ParsedMetrics {
+  metrics: Record<string, MetricValue>;
+  /** Keys that appeared more than once and are therefore arrays. */
+  repeatedMetrics: string[];
+}
+
+/**
+ * Parse an ORFS stage metrics file without losing repeated keys.
+ *
+ * ORFS appends a block of metrics per sub-run, so a single file legitimately
+ * contains the same key more than once -- `4_1_cts.json` has 63 key
+ * occurrences across 55 distinct keys, with `cts__utilization__before__dpl`
+ * recorded as both 76.7787 and 82.1146. `JSON.parse` keeps only the last
+ * occurrence and reports nothing, so a naive reader silently drops the earlier
+ * pass. A reviver cannot recover them either: duplicates are collapsed while
+ * the object is built, before any reviver runs.
+ *
+ * So: validate with `JSON.parse`, then walk the text collecting top-level
+ * key/value spans in file order. The walk tracks nesting depth and string
+ * state rather than pattern-matching, so an object- or array-valued metric
+ * cannot desynchronise it.
+ */
+export function parseMetricsPreservingDuplicates(text: string): ParsedMetrics {
+  // Validate first so a malformed file produces a clean JSON error rather than
+  // a confusing failure part-way through the scan.
+  const validated: unknown = JSON.parse(text);
+  if (validated === null || typeof validated !== "object" || Array.isArray(validated)) {
+    throw new SyntaxError("Metrics file must contain a JSON object at the top level");
+  }
+
+  const ordered: Array<[string, unknown]> = [];
+  let i = 0;
+  const n = text.length;
+
+  const skipWhitespace = (): void => {
+    while (i < n && /\s/.test(text[i]!)) i += 1;
+  };
+
+  /** Consume one JSON string starting at a quote, returning its parsed value. */
+  const readString = (): string => {
+    const start = i;
+    i += 1; // opening quote
+    while (i < n) {
+      const ch = text[i]!;
+      if (ch === "\\") {
+        i += 2;
+        continue;
+      }
+      if (ch === '"') {
+        i += 1;
+        return JSON.parse(text.slice(start, i)) as string;
+      }
+      i += 1;
+    }
+    throw new SyntaxError("Unterminated string in metrics file");
+  };
+
+  /** Consume one JSON value, returning its parsed form. */
+  const readValue = (): unknown => {
+    skipWhitespace();
+    const start = i;
+    const ch = text[i];
+    if (ch === '"') {
+      readString();
+      return JSON.parse(text.slice(start, i));
+    }
+    if (ch === "{" || ch === "[") {
+      let depth = 0;
+      while (i < n) {
+        const c = text[i]!;
+        if (c === '"') {
+          readString();
+          continue;
+        }
+        if (c === "{" || c === "[") depth += 1;
+        else if (c === "}" || c === "]") {
+          depth -= 1;
+          if (depth === 0) {
+            i += 1;
+            return JSON.parse(text.slice(start, i));
+          }
+        }
+        i += 1;
+      }
+      throw new SyntaxError("Unterminated object or array in metrics file");
+    }
+    // A bare literal: number, true, false or null.
+    while (i < n && !",}\n\r\t ".includes(text[i]!)) i += 1;
+    return JSON.parse(text.slice(start, i).trim());
+  };
+
+  skipWhitespace();
+  if (text[i] !== "{") throw new SyntaxError("Metrics file must start with '{'");
+  i += 1;
+
+  for (;;) {
+    skipWhitespace();
+    if (i >= n) break;
+    if (text[i] === "}") break;
+    if (text[i] === ",") {
+      i += 1;
+      continue;
+    }
+    if (text[i] !== '"') break;
+    const key = readString();
+    skipWhitespace();
+    if (text[i] !== ":") throw new SyntaxError(`Expected ':' after key '${key}'`);
+    i += 1;
+    ordered.push([key, readValue()]);
+  }
+
+  const counts = new Map<string, number>();
+  for (const [key] of ordered) counts.set(key, (counts.get(key) ?? 0) + 1);
+
+  const metrics: Record<string, MetricValue> = {};
+  const repeatedMetrics: string[] = [];
+  for (const [key, value] of ordered) {
+    if ((counts.get(key) ?? 0) > 1) {
+      if (!Array.isArray(metrics[key])) {
+        metrics[key] = [];
+        repeatedMetrics.push(key);
+      }
+      (metrics[key] as unknown[]).push(value);
+    } else {
+      metrics[key] = value;
+    }
+  }
+
+  return { metrics, repeatedMetrics };
+}
+
+/**
+ * Find the platform a design belongs to.
+ *
+ * `platform` is optional so a caller can ask for a design by name alone, which
+ * is how people actually refer to them ("gcd", "ibex"). Ambiguity is reported
+ * rather than guessed at.
+ */
+export function resolvePlatform(design: string, platform?: string | null): string {
+  const settings = getSettings();
+  const platforms = settings.platforms;
+
+  if (platform != null && platform !== "") {
+    if (!platforms.includes(platform)) {
+      throw new ValidationError(
+        `Platform '${platform}' not found. Available platforms: ${platforms.join(", ") || "none"}`,
+      );
+    }
+    if (!settings.designs(platform).includes(design)) {
+      throw new ValidationError(
+        `Design '${design}' not found for platform '${platform}'. ` +
+          `Available designs: ${settings.designs(platform).join(", ") || "none"}`,
+      );
+    }
+    return platform;
+  }
+
+  const matches = platforms.filter((p) => settings.designs(p).includes(design));
+  if (matches.length === 1) return matches[0]!;
+  if (matches.length === 0) {
+    const known = platforms
+      .flatMap((p) => settings.designs(p).map((d) => `${p}/${d}`))
+      .join(", ");
+    throw new ValidationError(
+      `Design '${design}' not found under any platform. Available designs: ${known || "none"}`,
+    );
+  }
+  throw new ValidationError(
+    `Design '${design}' exists under multiple platforms (${matches.join(", ")}). ` +
+      `Pass platform to disambiguate.`,
+  );
+}
+
+/** Stage stems that have a metrics file, plus those that only have a log. */
+function availableStems(logsDir: string): { withMetrics: string[]; logOnly: string[] } {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(logsDir);
+  } catch {
+    return { withMetrics: [], logOnly: [] };
+  }
+  const json = new Set<string>();
+  const logs = new Set<string>();
+  for (const e of entries) {
+    if (e.endsWith(".json")) json.add(e.slice(0, -".json".length));
+    else if (e.endsWith(".log")) logs.add(e.slice(0, -".log".length));
+  }
+  const withMetrics = [...json].sort();
+  const logOnly = [...logs].filter((s) => !json.has(s)).sort();
+  return { withMetrics, logOnly };
+}
+
+/**
+ * Map a requested stage onto the stems actually present.
+ *
+ * Resolution is by discovery rather than a hardcoded stem table: ORFS
+ * renumbers stages between releases, and a table would silently return nothing
+ * on a tree that had moved on.
+ */
+export function resolveStages(stems: string[], stage: string): string[] {
+  const wanted = stage.trim().toLowerCase();
+  if (wanted === "" || wanted === "all") return [...stems];
+
+  const exact = stems.filter((s) => s.toLowerCase() === wanted);
+  if (exact.length > 0) return exact;
+
+  const namespaceFragment = NAMESPACE_ALIASES[wanted];
+  if (namespaceFragment !== undefined) {
+    const hits = stems.filter((s) => s.toLowerCase().includes(namespaceFragment));
+    if (hits.length > 0) return hits;
+  }
+
+  const groupPrefix = GROUP_ALIASES[wanted];
+  if (groupPrefix !== undefined) {
+    const hits = stems.filter((s) => s.startsWith(groupPrefix));
+    if (hits.length > 0) return hits;
+  }
+
+  return stems.filter((s) => s.toLowerCase().includes(wanted));
+}
+
+export interface GateRule {
+  value: unknown;
+  compare: string;
+  level?: string;
+}
+
+/** Compare a metric against a rules-base threshold. */
+export function compareGate(value: unknown, compare: string, threshold: unknown): boolean | null {
+  if (compare === "==") return value === threshold;
+  if (compare === "!=") return value !== threshold;
+  if (typeof value !== "number" || typeof threshold !== "number") return null;
+  if (compare === ">=") return value >= threshold;
+  if (compare === "<=") return value <= threshold;
+  if (compare === ">") return value > threshold;
+  if (compare === "<") return value < threshold;
+  return null;
+}
+
+interface StageMetrics {
+  stage: string;
+  metrics: Record<string, MetricValue>;
+}
+
+export interface GateVerdict {
+  metric: string;
+  stage: string;
+  value: unknown;
+  threshold: unknown;
+  compare: string;
+  level: string;
+  status: "pass" | "fail" | "unknown";
+  /** True when the metric was recorded more than once and the last was judged. */
+  ambiguous?: boolean;
+}
+
+/**
+ * Evaluate every rule whose metric appears in the stages that were read.
+ *
+ * Matching on presence rather than a namespace-to-file table means a rule is
+ * checked wherever its metric turns up, and `stage: "all"` covers the lot.
+ */
+export function evaluateGates(
+  stages: StageMetrics[],
+  rules: Record<string, GateRule>,
+): { gates: GateVerdict[]; unmatched: Array<{ metric: string; threshold: unknown; compare: string; level: string }> } {
+  const gates: GateVerdict[] = [];
+  const unmatched: Array<{ metric: string; threshold: unknown; compare: string; level: string }> = [];
+
+  for (const [metric, rule] of Object.entries(rules)) {
+    // ORFS treats a rule with no explicit level as an error-level gate.
+    const level = rule.level ?? "error";
+    const owner = stages.find((s) => metric in s.metrics);
+    if (owner === undefined) {
+      unmatched.push({ metric, threshold: rule.value, compare: rule.compare, level });
+      continue;
+    }
+
+    const raw = owner.metrics[metric];
+    // A repeated key was recorded once per sub-run; judge the final value,
+    // which is what ORFS's own checkers see, and say that it was ambiguous.
+    const ambiguous = Array.isArray(raw);
+    const value = ambiguous ? (raw as unknown[])[(raw as unknown[]).length - 1] : raw;
+
+    const result = compareGate(value, rule.compare, rule.value);
+    gates.push({
+      metric,
+      stage: owner.stage,
+      value,
+      threshold: rule.value,
+      compare: rule.compare,
+      level,
+      status: result === null ? "unknown" : result ? "pass" : "fail",
+      ...(ambiguous && { ambiguous: true }),
+    });
+  }
+
+  return { gates, unmatched };
+}
+
+export interface LogDiagnostics {
+  path: string;
+  errors: string[];
+  warnings: string[];
+  errorCount: number;
+  warningCount: number;
+  /** True when more diagnostics existed than are listed. */
+  truncated: boolean;
+}
+
+/** Pull ORFS's own tagged diagnostics out of a stage log. */
+export function extractLogDiagnostics(logPath: string, relPath: string): LogDiagnostics | null {
+  let text: string;
+  try {
+    text = fs.readFileSync(logPath, "utf8");
+  } catch {
+    return null;
+  }
+
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  let errorCount = 0;
+  let warningCount = 0;
+
+  for (const line of text.split(/\r?\n/)) {
+    if (ERROR_LINE.test(line)) {
+      errorCount += 1;
+      if (errors.length < MAX_LOG_LINES) errors.push(line.trim());
+    } else if (WARNING_LINE.test(line)) {
+      warningCount += 1;
+      if (warnings.length < MAX_LOG_LINES) warnings.push(line.trim());
+    }
+  }
+
+  return {
+    path: relPath,
+    errors,
+    warnings,
+    errorCount,
+    warningCount,
+    truncated: errorCount > errors.length || warningCount > warnings.length,
+  };
+}
+
+/** Structured failure, matching the error-code style the image tools use. */
+function failure(error: string, message: string): string {
+  return JSON.stringify({
+    platform: null,
+    design: null,
+    variant: null,
+    stage: null,
+    logs_path: null,
+    stages: [],
+    available_stages: [],
+    gates: [],
+    unmatched_gates: [],
+    gate_summary: null,
+    rules_path: null,
+    message,
+    error,
+  });
+}
+
+/**
+ * Read ORFS per-stage metrics, the design's rules-base gates, and the tagged
+ * diagnostics from each stage log.
+ *
+ * This exists because the capability study found ~39% of all shell calls were
+ * agents doing exactly this by hand with find/cat/jq/grep -- the single
+ * largest category of MCP bypass.
+ */
+export class ReadOrfsMetricsTool extends BaseTool {
+  constructor(manager: OpenROADManager) {
+    super(manager);
+  }
+
+  async execute(
+    design: string,
+    stage = "all",
+    platform?: string | null,
+    variant = "base",
+  ): Promise<string> {
+    let resolvedPlatform: string;
+    try {
+      validatePathSegment(design, "design");
+      validatePathSegment(variant, "variant");
+      resolvedPlatform = resolvePlatform(design, platform);
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        return failure(e.constructor.name, e.message);
+      }
+      return failure("UnexpectedError", (e as Error).message ?? String(e));
+    }
+
+    const settings = getSettings();
+    const flowPath = settings.flowPath;
+    const logsBase = path.join(flowPath, "logs", resolvedPlatform, design);
+    const logsDir = path.join(logsBase, variant);
+
+    try {
+      validateSafePathContainment(logsDir, path.join(flowPath, "logs"), "logs directory");
+    } catch (e) {
+      return failure((e as ValidationError).constructor.name, (e as Error).message);
+    }
+
+    if (!fs.existsSync(logsDir)) {
+      let variants: string[] = [];
+      try {
+        variants = fs
+          .readdirSync(logsBase, { withFileTypes: true })
+          .filter((d) => d.isDirectory())
+          .map((d) => d.name);
+      } catch {
+        variants = [];
+      }
+      return failure(
+        "RunNotFound",
+        `No logs for ${resolvedPlatform}/${design} variant '${variant}'. ` +
+          `Available variants: ${variants.join(", ") || "none"}`,
+      );
+    }
+
+    const { withMetrics, logOnly } = availableStems(logsDir);
+    const allStems = [...withMetrics, ...logOnly].sort();
+    const selected = resolveStages(allStems, stage);
+
+    if (selected.length === 0) {
+      return failure(
+        "StageNotFound",
+        `Stage '${stage}' matched nothing for ${resolvedPlatform}/${design}/${variant}. ` +
+          `Available stages: ${allStems.join(", ") || "none"}`,
+      );
+    }
+
+    const relLogs = path.relative(flowPath, logsDir);
+    const stages: OrfsStageMetrics[] = [];
+
+    for (const stem of selected) {
+      const metricsPath = path.join(logsDir, `${stem}.json`);
+      const logPath = path.join(logsDir, `${stem}.log`);
+
+      let metrics: Record<string, unknown> = {};
+      let repeatedMetrics: string[] = [];
+      let stageError: string | null = null;
+      let relMetrics: string | null = null;
+
+      if (fs.existsSync(metricsPath)) {
+        relMetrics = path.relative(flowPath, metricsPath);
+        try {
+          const parsed = parseMetricsPreservingDuplicates(fs.readFileSync(metricsPath, "utf8"));
+          metrics = parsed.metrics;
+          repeatedMetrics = parsed.repeatedMetrics;
+        } catch (e) {
+          // A stage that crashed can leave a half-written metrics file. Say so
+          // rather than dropping the stage: its log usually explains why.
+          stageError = `MalformedMetrics: ${(e as Error).message}`;
+        }
+      }
+
+      stages.push({
+        stage: stem,
+        metricsPath: relMetrics,
+        metrics,
+        repeatedMetrics,
+        log: extractLogDiagnostics(logPath, path.relative(flowPath, logPath)),
+        error: stageError,
+      });
+    }
+
+    // Gates
+    const rulesPath = path.join(flowPath, "designs", resolvedPlatform, design, "rules-base.json");
+    let rules: Record<string, GateRule> = {};
+    let relRules: string | null = null;
+    let message: string | null = null;
+
+    if (fs.existsSync(rulesPath)) {
+      relRules = path.relative(flowPath, rulesPath);
+      try {
+        rules = JSON.parse(fs.readFileSync(rulesPath, "utf8")) as Record<string, GateRule>;
+      } catch (e) {
+        message = `rules-base.json could not be parsed: ${(e as Error).message}`;
+      }
+    } else {
+      message = `No rules-base.json for ${resolvedPlatform}/${design}; no gates to evaluate.`;
+    }
+
+    const { gates, unmatched } = evaluateGates(stages, rules);
+    const failing = gates.filter((g) => g.status === "fail");
+
+    return this.formatResult(
+      OrfsMetricsResult.parse({
+        platform: resolvedPlatform,
+        design,
+        variant,
+        stage,
+        logsPath: relLogs,
+        stages,
+        availableStages: allStems,
+        gates,
+        unmatchedGates: unmatched,
+        gateSummary: {
+          total: gates.length,
+          pass: gates.filter((g) => g.status === "pass").length,
+          fail: failing.length,
+          unknown: gates.filter((g) => g.status === "unknown").length,
+          failingErrors: failing.filter((g) => g.level === "error").length,
+          failingWarnings: failing.filter((g) => g.level !== "error").length,
+          unmatched: unmatched.length,
+        },
+        rulesPath: relRules,
+        message,
+      }) as unknown as Record<string, unknown>,
+    );
+  }
+}

--- a/typescript/src/tools/report_images.ts
+++ b/typescript/src/tools/report_images.ts
@@ -29,7 +29,12 @@ const MAX_IMAGE_SIZE_MB = 50;
  */
 const RESIZE_LADDER_FACTOR = 0.75;
 const QUALITY_LADDER = [85, 70, 55] as const;
-const MAX_ENCODE_ATTEMPTS = 12;
+/** Safety valve on the search, not a tuning knob. It has to clear the whole
+ * default ladder or the cap silently truncates it: 1568px down to the 512px
+ * floor at 0.75 is five size rungs, times three quality rungs, is fifteen. At
+ * the old 12 a full-size image never reached its smallest rung -- the one rung
+ * that exists for images nothing else fits. */
+const MAX_ENCODE_ATTEMPTS = 24;
 
 /** An MCP content block: a real image block, or accompanying text. */
 export type ContentBlock =
@@ -275,16 +280,21 @@ async function loadAndCompressImage(
 
   try {
     let dim = Math.min(longEdge, maxDimension);
-    let best: { buf: Buffer; dim: number } | null = null;
+    let best: { buf: Buffer; dim: number; quality: number } | null = null;
     let attempts = 0;
 
-    for (const quality of QUALITY_LADDER) {
-      let rungDim = dim;
-      for (;;) {
+    // Quality is shed before resolution. A congestion or routing image carries
+    // its signal in fine wire and via detail, which downsampling destroys
+    // outright, while WebP quality loss degrades it gracefully -- so every
+    // quality rung is tried at the current size before the image is made
+    // smaller. The previous order inverted this and returned a 512px q85
+    // thumbnail where a full-resolution q70 encoding was within budget.
+    while (attempts < MAX_ENCODE_ATTEMPTS) {
+      for (const quality of QUALITY_LADDER) {
         if (attempts >= MAX_ENCODE_ATTEMPTS) break;
         attempts += 1;
         const buf = await sharp(imagePath)
-          .resize(rungDim, rungDim, {
+          .resize(dim, dim, {
             fit: "inside",
             withoutEnlargement: true,
             kernel: "lanczos3",
@@ -292,16 +302,13 @@ async function loadAndCompressImage(
           .webp({ quality })
           .toBuffer();
 
-        if (buf.length <= targetBytes) return await describeEncoded(buf, rungDim, quality);
+        if (buf.length <= targetBytes) return await describeEncoded(buf, dim, quality);
         // Remember the smallest encoding produced, so a budget that nothing
         // satisfies still returns the closest image rather than raw bytes.
-        if (best === null || buf.length < best.buf.length) best = { buf, dim: rungDim };
-        if (rungDim <= minDimension) break;
-        rungDim = Math.max(minDimension, Math.floor(rungDim * RESIZE_LADDER_FACTOR));
+        if (best === null || buf.length < best.buf.length) best = { buf, dim, quality };
       }
-      // Next quality rung restarts from the capped dimension.
-      dim = Math.min(longEdge, maxDimension);
-      if (attempts >= MAX_ENCODE_ATTEMPTS) break;
+      if (dim <= minDimension) break;
+      dim = Math.max(minDimension, Math.floor(dim * RESIZE_LADDER_FACTOR));
     }
 
     if (best === null) return rawFallback(sniffedFormat, origW, origH);
@@ -309,7 +316,9 @@ async function loadAndCompressImage(
       { imagePath, maxSizeKb, resultBytes: best.buf.length },
       "Image could not be squeezed within its base64 budget; returning the smallest encoding produced",
     );
-    return await describeEncoded(best.buf, best.dim, QUALITY_LADDER[QUALITY_LADDER.length - 1]!);
+    // Report the quality that actually produced this buffer; the fallback used
+    // to hardcode the last ladder rung and mislabel a q85 encoding as q55.
+    return await describeEncoded(best.buf, best.dim, best.quality);
   } catch (e) {
     logger.warn({ err: e, imagePath }, "Image compression failed; returning raw bytes with null dims");
     return rawFallback(sniffedFormat, origW, origH);

--- a/typescript/src/tools/report_images.ts
+++ b/typescript/src/tools/report_images.ts
@@ -14,13 +14,65 @@ import {
   validateSafePathContainment,
 } from "../utils/path_security.js";
 import { getSettings } from "../config/settings.js";
+import { IMAGE_DEFAULTS } from "../constants.js";
 import { getLogger } from "../utils/logging.js";
 import { BaseTool } from "./base.js";
 
 const logger = getLogger("tools.report_images");
 
-const MAX_BASE64_SIZE_KB = 15;
 const MAX_IMAGE_SIZE_MB = 50;
+
+/**
+ * Longest-edge ladder walked when an image does not fit its byte budget.
+ * Each rung is tried at descending WebP quality before the next rung down, so
+ * detail is traded away gradually instead of collapsing straight to the floor.
+ */
+const RESIZE_LADDER_FACTOR = 0.75;
+const QUALITY_LADDER = [85, 70, 55] as const;
+const MAX_ENCODE_ATTEMPTS = 12;
+
+/** An MCP content block: a real image block, or accompanying text. */
+export type ContentBlock =
+  | { type: "image"; data: string; mimeType: string }
+  | { type: "text"; text: string };
+
+export interface ImageContentResult {
+  blocks: ContentBlock[];
+  isError: boolean;
+}
+
+/**
+ * Resolve the image budget, tolerating a settings object that predates these
+ * fields or supplies a nonsense value. A missing knob must fall back to the
+ * documented default, never propagate NaN into sharp.
+ */
+function resolveImageBudget(overrideKb?: number | null): {
+  maxSizeKb: number;
+  maxDimension: number;
+  minDimension: number;
+} {
+  const settings = getSettings() as Partial<{
+    IMAGE_MAX_BASE64_KB: number;
+    IMAGE_MAX_DIMENSION: number;
+    IMAGE_MIN_DIMENSION: number;
+  }>;
+  const positive = (value: unknown, fallback: number): number =>
+    typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+
+  return {
+    maxSizeKb: positive(
+      overrideKb,
+      positive(settings.IMAGE_MAX_BASE64_KB, IMAGE_DEFAULTS.MAX_BASE64_KB),
+    ),
+    maxDimension: positive(settings.IMAGE_MAX_DIMENSION, IMAGE_DEFAULTS.MAX_DIMENSION),
+    minDimension: positive(settings.IMAGE_MIN_DIMENSION, IMAGE_DEFAULTS.MIN_DIMENSION),
+  };
+}
+
+/** MIME type for a base64 payload, so callers can emit a real image block. */
+function mimeTypeForFormat(format: string): string {
+  return format === "png" ? "image/png" : "image/webp";
+}
 
 const IMAGE_TYPE_MAPPING: Record<string, string> = {
   cts_clk: "clock_visualization",
@@ -119,11 +171,6 @@ export function isReportImage(filename: string): boolean {
  * reporting a blanket "webp" would misdescribe the payload to any consumer that
  * trusts this field instead of sniffing the header.
  */
-function imageFormat(filename: string, compressionApplied: boolean): string {
-  if (compressionApplied) return "webp";
-  return filename.toLowerCase().endsWith(".webp") ? "webp" : "png";
-}
-
 /** Strip the report-image extension, including the doubled `.webp.png` form. */
 function stripImageExtension(filename: string): string {
   const lower = filename.toLowerCase();
@@ -156,87 +203,152 @@ interface CompressResult {
   originalHeight: number | null;
   width: number | null;
   height: number | null;
+  /** Actual encoded format ("webp" / "png"), sniffed rather than guessed. */
+  format: string;
 }
 
 /**
- * Compress an image to fit within `maxSizeKb` of base64 output using sharp
- * (lanczos3 resize, WebP quality 85). Falls back to raw bytes with null
- * dimensions when sharp fails.
+ * Load an image, resizing only as far as its byte budget actually requires.
+ *
+ * The previous implementation guessed a scale factor from the raw file size in
+ * one shot (`sqrt(targetBytes / originalSize)`), which ignores that the output
+ * is re-encoded as WebP. It over-shrank badly -- a 1099x1099 render landed on
+ * the 256x256 floor, a 35x reduction, which is unreadable for the congestion
+ * and IR-drop heatmaps these tools exist to show.
+ *
+ * Instead: cap the long edge at `maxDimension`, encode, and step down a
+ * quality/size ladder only while the result still exceeds budget. Most images
+ * now pass through at full resolution.
  */
 async function loadAndCompressImage(
   imagePath: string,
-  maxSizeKb: number = MAX_BASE64_SIZE_KB,
+  overrideMaxSizeKb?: number | null,
 ): Promise<CompressResult> {
+  const { maxSizeKb, maxDimension, minDimension } = resolveImageBudget(overrideMaxSizeKb);
   const originalSize = fs.statSync(imagePath).size;
-  const estimatedBase64 = Math.floor((originalSize * 4) / 3);
+  // base64 inflates by 4/3, so the byte budget is 3/4 of the stated KB budget.
+  const targetBytes = Math.floor((maxSizeKb * 1024 * 3) / 4);
 
-  if (estimatedBase64 / 1024 <= maxSizeKb) {
-    try {
-      const rawBytes = fs.readFileSync(imagePath);
-      const meta = await sharp(imagePath).metadata();
-      return {
-        imageBytes: rawBytes,
-        compressionApplied: false,
-        originalSize,
-        compressedSize: originalSize,
-        originalWidth: meta.width ?? null,
-        originalHeight: meta.height ?? null,
-        width: meta.width ?? null,
-        height: meta.height ?? null,
-      };
-    } catch (e) {
-      logger.warn({ err: e, imagePath }, "sharp.metadata() failed on small image; returning raw bytes with null dims");
-      return {
-        imageBytes: fs.readFileSync(imagePath),
-        compressionApplied: false,
-        originalSize,
-        compressedSize: originalSize,
-        originalWidth: null,
-        originalHeight: null,
-        width: null,
-        height: null,
-      };
-    }
+  const rawFallback = (
+    format: string,
+    width: number | null = null,
+    height: number | null = null,
+  ): CompressResult => ({
+    imageBytes: fs.readFileSync(imagePath),
+    compressionApplied: false,
+    originalSize,
+    compressedSize: originalSize,
+    originalWidth: width,
+    originalHeight: height,
+    width,
+    height,
+    format,
+  });
+
+  let meta;
+  try {
+    meta = await sharp(imagePath).metadata();
+  } catch (e) {
+    logger.warn(
+      { err: e, imagePath },
+      "sharp.metadata() failed; returning raw bytes with null dims",
+    );
+    return rawFallback(formatFromExtension(imagePath));
+  }
+
+  const origW = meta.width ?? null;
+  const origH = meta.height ?? null;
+  const sniffedFormat = meta.format === "png" ? "png" : "webp";
+
+  // Already within budget and within the resolution ceiling: hand back the
+  // original bytes untouched. This is the common case now that the budget is
+  // measured in MB rather than 15 KB.
+  const longEdge = Math.max(origW ?? 0, origH ?? 0);
+  if (originalSize <= targetBytes && (longEdge === 0 || longEdge <= maxDimension)) {
+    return rawFallback(sniffedFormat, origW, origH);
+  }
+
+  if (origW === null || origH === null) {
+    logger.warn({ imagePath }, "Image dimensions unavailable; returning raw bytes");
+    return rawFallback(sniffedFormat);
   }
 
   try {
-    const targetBytes = Math.floor((maxSizeKb * 1024 * 3) / 4);
-    const scale = Math.sqrt(targetBytes / originalSize);
-    const meta = await sharp(imagePath).metadata();
-    if (!meta.width || !meta.height) {
-      throw new Error("Image dimensions unavailable");
+    let dim = Math.min(longEdge, maxDimension);
+    let best: { buf: Buffer; dim: number } | null = null;
+    let attempts = 0;
+
+    for (const quality of QUALITY_LADDER) {
+      let rungDim = dim;
+      for (;;) {
+        if (attempts >= MAX_ENCODE_ATTEMPTS) break;
+        attempts += 1;
+        const buf = await sharp(imagePath)
+          .resize(rungDim, rungDim, {
+            fit: "inside",
+            withoutEnlargement: true,
+            kernel: "lanczos3",
+          })
+          .webp({ quality })
+          .toBuffer();
+
+        if (buf.length <= targetBytes) return await describeEncoded(buf, rungDim, quality);
+        // Remember the smallest encoding produced, so a budget that nothing
+        // satisfies still returns the closest image rather than raw bytes.
+        if (best === null || buf.length < best.buf.length) best = { buf, dim: rungDim };
+        if (rungDim <= minDimension) break;
+        rungDim = Math.max(minDimension, Math.floor(rungDim * RESIZE_LADDER_FACTOR));
+      }
+      // Next quality rung restarts from the capped dimension.
+      dim = Math.min(longEdge, maxDimension);
+      if (attempts >= MAX_ENCODE_ATTEMPTS) break;
     }
-    const origW = meta.width;
-    const origH = meta.height;
-    const newW = Math.max(Math.round(origW * scale), 256);
-    const newH = Math.max(Math.round(origH * scale), 256);
-    const compressed = await sharp(imagePath)
-      .resize(newW, newH, { kernel: "lanczos3" })
-      .webp({ quality: 85 })
-      .toBuffer();
-    return {
-      imageBytes: compressed,
-      compressionApplied: true,
-      originalSize,
-      compressedSize: compressed.length,
-      originalWidth: meta.width ?? null,
-      originalHeight: meta.height ?? null,
-      width: newW,
-      height: newH,
-    };
+
+    if (best === null) return rawFallback(sniffedFormat, origW, origH);
+    logger.warn(
+      { imagePath, maxSizeKb, resultBytes: best.buf.length },
+      "Image could not be squeezed within its base64 budget; returning the smallest encoding produced",
+    );
+    return await describeEncoded(best.buf, best.dim, QUALITY_LADDER[QUALITY_LADDER.length - 1]!);
   } catch (e) {
     logger.warn({ err: e, imagePath }, "Image compression failed; returning raw bytes with null dims");
+    return rawFallback(sniffedFormat, origW, origH);
+  }
+
+  async function describeEncoded(
+    buf: Buffer,
+    requestedDim: number,
+    quality: number,
+  ): Promise<CompressResult> {
+    // Read the dimensions back off the encoded buffer: `fit: "inside"`
+    // preserves aspect ratio, so the short edge is not `requestedDim`.
+    let outW: number | null = requestedDim;
+    let outH: number | null = requestedDim;
+    try {
+      const outMeta = await sharp(buf).metadata();
+      outW = outMeta.width ?? requestedDim;
+      outH = outMeta.height ?? requestedDim;
+    } catch {
+      /* fall back to the requested box */
+    }
+    logger.debug({ imagePath, outW, outH, quality, bytes: buf.length }, "Encoded report image");
     return {
-      imageBytes: fs.readFileSync(imagePath),
-      compressionApplied: false,
+      imageBytes: buf,
+      compressionApplied: true,
       originalSize,
-      compressedSize: originalSize,
-      originalWidth: null,
-      originalHeight: null,
-      width: null,
-      height: null,
+      compressedSize: buf.length,
+      originalWidth: origW,
+      originalHeight: origH,
+      width: outW,
+      height: outH,
+      format: "webp",
     };
   }
+}
+
+/** Last-resort format guess when the bytes cannot be sniffed. */
+function formatFromExtension(filename: string): string {
+  return filename.toLowerCase().endsWith(".png") ? "png" : "webp";
 }
 
 /** Lists .webp report images for a specific platform/design/run. */
@@ -371,11 +483,19 @@ export class ReadReportImageTool extends BaseTool {
     super(manager);
   }
 
+  /**
+   * Read an image and return the legacy JSON payload, base64 included.
+   *
+   * `maxSizeKb` overrides the configured IMAGE_MAX_BASE64_KB budget for this
+   * call, for the occasional case where a caller wants a deliberately small
+   * thumbnail or a deliberately large one.
+   */
   async execute(
     platform: string,
     design: string,
     runSlug: string,
     imageName: string,
+    maxSizeKb?: number | null,
   ): Promise<string> {
     let reportsBase: string;
     let runPath: string;
@@ -477,7 +597,7 @@ export class ReadReportImageTool extends BaseTool {
     }
 
     try {
-      const r = await loadAndCompressImage(imagePath);
+      const r = await loadAndCompressImage(imagePath, maxSizeKb);
       const imageData = r.imageBytes.toString("base64");
       const [stage, type] = classifyImageType(imageName);
       const compressionRatio =
@@ -487,7 +607,7 @@ export class ReadReportImageTool extends BaseTool {
 
       const metadata = ImageMetadata.parse({
         filename: imageName,
-        format: imageFormat(imageName, r.compressionApplied),
+        format: r.format,
         sizeBytes: r.compressedSize,
         width: r.width,
         height: r.height,
@@ -523,5 +643,54 @@ export class ReadReportImageTool extends BaseTool {
         }) as unknown as Record<string, unknown>,
       );
     }
+  }
+
+  /**
+   * Read an image and return it as MCP content blocks.
+   *
+   * The base64 payload goes in a real `image` block so a vision model can see
+   * it. Returning it inside a text block -- as this tool used to -- delivered
+   * 33 KB of unreadable base64 to a model that then tried, and failed, to
+   * decode it by hand. The accompanying text block carries the metadata only,
+   * with `image_data` stripped so the payload is not sent twice.
+   */
+  async executeContent(
+    platform: string,
+    design: string,
+    runSlug: string,
+    imageName: string,
+    maxSizeKb?: number | null,
+  ): Promise<ImageContentResult> {
+    const json = await this.execute(platform, design, runSlug, imageName, maxSizeKb);
+
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(json) as Record<string, unknown>;
+    } catch {
+      return { blocks: [{ type: "text", text: json }], isError: true };
+    }
+
+    const imageData = parsed["image_data"];
+    const metadata = parsed["metadata"] as { format?: string } | null | undefined;
+    if (typeof imageData !== "string" || imageData.length === 0) {
+      // An error result: no image to show, so the JSON is the whole answer.
+      return { blocks: [{ type: "text", text: json }], isError: parsed["error"] != null };
+    }
+
+    const { image_data: _omitted, ...withoutData } = parsed as Record<string, unknown> & {
+      image_data?: unknown;
+    };
+
+    return {
+      blocks: [
+        {
+          type: "image",
+          data: imageData,
+          mimeType: mimeTypeForFormat(metadata?.format ?? "webp"),
+        },
+        { type: "text", text: JSON.stringify(withoutData) },
+      ],
+      isError: false,
+    };
   }
 }


### PR DESCRIPTION
# Merge request — MCP capability enhancements


---

## Summary

This branch adds five new tools to the OpenROAD MCP server and improves what the existing tools tell
you about their own results. The goal is to let an assistant do real physical-design work *through*
the server, instead of falling back to shell commands for anything the server does not cover.

The work is grounded in a capability study we ran against the current server across eleven realistic
scenarios. That study found the server was being used for only about **30%** of the work — the other
70% was shell commands filling gaps. This branch closes the largest of those gaps.

---

## Background — where the gaps were

We measured what an assistant actually did when given real physical-design tasks. Four patterns
accounted for nearly all the work that went around the server:

**1. Reading flow results.** Roughly **39% of all shell commands** were spent finding, reading and
hand-parsing the metrics, quality-of-result thresholds and stage logs that the flow writes to disk.
The server exposed none of this, so every session rediscovered it from scratch.

**2. Running a flow stage.** The server had no way to run one. Sessions resorted to launching the
build in the background and then polling a raw log file for hours. In one session the assistant
described being "reduced to tailing and grepping a raw log", with no structured view of what was
happening or how far along it was.

**3. Looking at report images.** The server could return a report image, but only as encoded text
rather than as a viewable image, and it shrank every picture to a fixed small size. Congestion and
voltage-drop heatmaps came back too small to read, and the assistant could not see them anyway.

**4. Re-reading large results.** A single timing report can run to tens of thousands of lines. To
find a handful of relevant rows, the whole result had to be fetched and re-read, because there was no
way to search what a session had already produced.

Alongside these, results carried very little information about themselves. When output was larger
than a session's internal capacity, the beginning was dropped to make room — and nothing in the
result said so. A caller could receive a partial answer that looked complete.

---

## What we changed

### New: read flow metrics and quality gates in one call

A new tool returns a design's per-stage metrics, its shipped quality-of-result thresholds already
**evaluated** against those metrics with a pass/fail verdict for each, and any errors or warnings the
flow logged for that stage.

Two details make it reliable rather than merely convenient:

- **Stage naming is flexible.** Callers can ask for a stage the way people talk about it ("cts",
  "route", "place"), by the internal name the threshold file uses, or by exact filename. Stages are
  discovered from the run itself, so a future flow release that renumbers its stages still works.
- **Repeated measurements are preserved.** The flow records some metrics more than once per stage —
  once per internal pass. Standard parsing silently keeps only the last value. This tool returns
  every recorded value, and names which metrics were recorded more than once, so a caller can see
  when a number changed during a stage rather than being shown one value with no indication there
  were others.

### New: run a flow stage as a tracked job

Three new tools start a stage, report on it while it runs, and stop it.

- Starting a stage returns a job handle **immediately**, so a multi-hour route does not block the
  call. Short stages can return their complete result inline instead, when the caller asks to wait.
- Output streams to a file, so a large run log is kept in full rather than being limited by a
  session's in-memory capacity.
- Polling a job returns **structured progress**: which stage is executing, the routing iteration,
  the live design-rule violation count, elapsed time, and processor and memory use — plus the tail of
  the log. This replaces the manual log-tailing pattern entirely.
- When a run finishes successfully, its result carries the stage metrics and gate verdicts directly,
  so no follow-up call is needed.
- Stopping a run terminates the entire process tree it created, so nothing is left running.
- Runs accept build-variable overrides, which is how engineers sweep settings. Overrides and stage
  names are checked against an allowlist before anything is launched, and variables that would change
  *how* the build executes rather than *what* it builds are refused. Concurrent runs are capped, each
  run has a time limit, and any run still going when the server stops is shut down with it.

### New: search a session's earlier output

A new tool searches the output of commands a session has already run, without re-running them or
re-sending a large result. Matches come back with the command they came from, their line number, and
optional surrounding lines.

Physical-design names contain brackets and dots, which are also pattern characters. A name pasted
directly is a *valid* pattern that quietly matches nothing — which is worse than an error, because
the caller is told there is nothing to find when it is the pattern that is wrong. The tool detects
this case, retries the text literally, and reports which interpretation produced the answer.

### Improved: report images are now viewable and readable

Images are returned as actual images rather than as encoded text, so they can be looked at. The size
budget is now configurable and far more generous, and images are reduced only as far as the budget
genuinely requires instead of always being shrunk to a fixed small size. On a representative
heatmap this is the difference between a 256×256 thumbnail and an 824×824 image — about **ten times
the detail** — while staying within a sensible payload size. A caller can also raise or lower the
budget for a single request.

### Improved: results now describe themselves

Every command result now reports how much output the command produced in total, how much (if any) was
dropped because it exceeded the session's capacity, and what that capacity is. When output is
dropped, a clear notice is placed at the top of the returned text, because a caller reads the output
before it reads anything else.

The practical effect is that a partial answer can no longer be mistaken for a complete one — and
equally, a caller can now **demonstrate** that a result is complete rather than assuming it.

---

## The result

**Server usage roughly doubled.** Re-running a focused set of the original scenarios against this
branch, work going through the server rose from about **30% to about 64%**.

Two specific outcomes stand out:

- **The signoff audit reversed completely.** The scenario that previously used the server *zero*
  times and answered entirely through 21 shell commands is now answered by **a single call**. In that
  re-run the assistant also correctly noticed that one gated metric had been recorded twice with
  different values, and explained that the verdict depended on which one was authoritative — an
  observation that is simply not available when only the last value survives.

- **The log-polling pattern is gone.** In the flow-run scenario the assistant used one call to check
  on the run and issued **no shell commands at all** to inspect it. Previously this was an
  open-ended loop of tailing and grepping.

Every session in the re-run successfully discovered and loaded the tools. In the original study, four
of eleven sessions never did — the server was connected but effectively invisible. That did not
recur.

---

## Confidence: what has been verified

**Automated tests.** The branch adds substantial test coverage; the full suite is **661 tests, all
passing**, with a clean build and no lint issues.

For the areas where a mistake would be silent rather than loud, we went further and deliberately
broke the implementation to confirm the tests actually catch it. Reverting the repeated-measurement
handling fails four tests; reverting the process-tree termination fails the test that checks nothing
is left running; removing output retention fails nine. These checks pass because the behaviour is
correct, not because the tests are lenient.

**Live validation.** Running the new tools against a real flow on the test server confirmed:

- Flow stages run successfully through the server, complete, and return their metrics and gate
  verdicts in the same result.
- Build-variable overrides reach the build exactly as written, confirmed by inspecting the flow's own
  log to see the setting take effect.
- Repeated metrics are returned in full — 37 such measurements were present across four stages in a
  single real run.
- Result self-reporting is populated correctly on every call.
- Searching a session's earlier output returns correct, attributed matches.

**Known limits, stated plainly.** Two areas have not yet been exercised end-to-end on real data: the
behaviour when output exceeds a session's capacity (the reports we generated stayed under it), and
progress reporting during a genuinely long route (the test run found its work already complete). Both
are covered by automated tests, and both are worth a follow-up run on a freshly cleaned design.
The image improvements were validated on generated images rather than on real flow renders.

---

## Configuration

All new behaviour works with no configuration. For deployments that want to tune it, new settings
control the image payload budget and dimension limits, how much recent output each session keeps for
searching, how many flow runs may execute at once, the flow-run time limit, and where run logs are
written. Defaults are documented alongside the existing settings.

## Compatibility

Changes to existing results are **additive** — new fields alongside the existing ones. One field that
previously reported an internal counter now reports something a caller can act on; it is documented
in this branch. Reference outputs and the tool catalogue have been regenerated to match.

## Documentation

The API reference, the security notes and the package README have been updated to cover the new
tools, the new settings, and the safety rules applied to flow runs.
